### PR TITLE
Feat/table identifiers

### DIFF
--- a/src/controllers/darwincore-controller.js
+++ b/src/controllers/darwincore-controller.js
@@ -14,12 +14,12 @@ const {
     LocalColeta,
     Familia,
     Genero,
+    Identificador,
     Subfamilia,
     Autor,
     Coletor,
     Variedade,
     Subespecie,
-    Usuario,
     ColecaoAnexa,
     Especie,
     Herbario,
@@ -88,13 +88,17 @@ const obterModeloDarwinCoreLotes = async (limit, offset, request, response) => {
         ],
         include: [
             {
+                model: Identificador,
+                as: 'identificadores',
+                attributes: {
+                    exclude: ['updated_at', 'created_at'],
+                },
+            },
+            {
                 model: Herbario,
             },
             {
                 model: TomboFoto,
-            },
-            {
-                model: Usuario,
             },
             {
                 model: LocalColeta,
@@ -248,8 +252,9 @@ const obterModeloDarwinCoreLotes = async (limit, offset, request, response) => {
                 identificationQualifier = 'aff.';
             }
         }
-        if (tombo.usuarios?.length > 0) {
-            nomeIdentificador = tombo.usuarios.map(usuario => padronizarNomeDarwincore(usuario.nome)).join(' | ');
+
+        if (tombo.identificadores?.length > 0) {
+            nomeIdentificador = tombo.identificadores.map(identificador => padronizarNomeDarwincore(identificador.nome)).join(' | ');
         }
 
         const linhasProcessadas = [];

--- a/src/models/Identificador.js
+++ b/src/models/Identificador.js
@@ -1,0 +1,39 @@
+function associate(modelos) {
+    const { Identificador, Tombo } = modelos;
+    Identificador.belongsToMany(Tombo, {
+        through: 'tombos_identificadores',
+        foreignKey: 'identificador_id',
+        otherKey: 'tombo_hcf',
+    });
+}
+
+export const defaultScope = {
+    attributes: {
+        exclude: ['created_at', 'updated_at'],
+    },
+};
+
+export default (Sequelize, DataTypes) => {
+    const attributes = {
+        id: {
+            type: DataTypes.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        nome: {
+            type: DataTypes.STRING(200),
+            allowNull: false,
+        },
+    };
+
+    const options = {
+        defaultScope,
+        freezeTableName: true,
+    };
+
+    const Model = Sequelize.define('identificadores', attributes, options);
+
+    Model.associate = associate;
+
+    return Model;
+};

--- a/src/models/Tombo.js
+++ b/src/models/Tombo.js
@@ -18,6 +18,8 @@ function associate(modelos) {
         Remessa,
         RetiradaExsiccata,
         TomboFoto,
+        TomboIdentificador,
+        Identificador,
     } = modelos;
 
     Tombo.hasMany(TomboFoto, {
@@ -25,21 +27,15 @@ function associate(modelos) {
     });
 
     Tombo.belongsToMany(Usuario, {
-        as: 'identificadores',
-        through: {
-            model: Alteracao,
-            scope: {
-                ativo: true,
-                status: 'APROVADO',
-                identificacao: true,
-            },
-        },
+        through: Alteracao,
         foreignKey: 'tombo_hcf',
     });
 
-    Tombo.belongsToMany(Usuario, {
-        through: Alteracao,
+    Tombo.belongsToMany(Identificador, {
+        as: 'identificadores',
+        through: TomboIdentificador,
         foreignKey: 'tombo_hcf',
+        otherKey: 'identificador_id',
     });
 
     Tombo.belongsToMany(Remessa, {

--- a/src/models/TomboIdentificador.js
+++ b/src/models/TomboIdentificador.js
@@ -1,0 +1,36 @@
+function associate() {}
+
+export const defaultScope = {
+    attributes: {
+        exclude: ['created_at', 'updated_at'],
+    },
+};
+
+export default (Sequelize, DataTypes) => {
+    const attributes = {
+        id: {
+            type: DataTypes.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        tombo_hcf: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+        },
+        identificador_id: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+        },
+    };
+
+    const options = {
+        defaultScope,
+        freezeTableName: true,
+    };
+
+    const Model = Sequelize.define('tombos_identificadores', attributes, options);
+
+    Model.associate = associate;
+
+    return Model;
+};


### PR DESCRIPTION
### Description

Adds two new models and relations to the identifiers table 

### Changes Made

- Adds two models
  - Identificadores
  - Tombos_identificadores
- Creates relations to be used in the darwincore controller
- Modifies the line that added the users to now add the identifiers

### How this was tested

 - The darwincore controller route has been requested via postman and the identifiers have been checked to see if they appear
 - It has been tested for when there is more than one identifier in the same record

