### PR TITLE
chore(usuarios-controller): prevent password return on user creation

### DIFF
--- a/src/controllers/usuarios-controller.js
+++ b/src/controllers/usuarios-controller.js
@@ -1,3 +1,4 @@
+import { UserRegistrationDTO } from '../dtos/UserRegistrationDTO';
 import BadRequestExeption from '../errors/bad-request-exception';
 import { comparaSenha, gerarSenha } from '../helpers/senhas';
 import { constroiPayloadUsuario, geraTokenUsuario } from '../helpers/tokens';
@@ -172,7 +173,8 @@ export const cadastro = (request, response, next) => {
             if (!retorno) {
                 throw new BadRequestExeption(112);
             }
-            response.status(codigos.CADASTRO_RETORNO).json(retorno);
+
+            response.status(codigos.CADASTRO_RETORNO).json(new UserRegistrationDTO(retorno));
         })
         .catch(next);
 };

--- a/src/dtos/UserRegistrationDTO.js
+++ b/src/dtos/UserRegistrationDTO.js
@@ -1,0 +1,25 @@
+export class UserRegistrationDTO {
+
+    ativo;
+    id;
+    email;
+    nome;
+    tipo_usuario_id;
+    herbario_id;
+    updated_at;
+    created_at;
+
+    constructor(userRegistration) {
+        this.ativo = userRegistration.ativo;
+        this.id = userRegistration.id;
+        this.email = userRegistration.email;
+        this.nome = userRegistration.nome;
+        this.tipo_usuario_id = userRegistration.tipo_usuario_id;
+        this.herbario_id = userRegistration.herbario_id;
+        this.updated_at = userRegistration.updated_at;
+        this.created_at = userRegistration.created_at;
+    }
+
+}
+
+export default {};


### PR DESCRIPTION
# Description

Prevents the password hash from being returned when the user is created

## Type of change

- [x] Bug fix

# How Has This Been Tested?

- [x] It was tested by creating a new user and checking that the hash would not be returned