### PR TITLE
fix(herbarios-controller): fix the herbarium update

### DIFF
--- a/src/controllers/herbarios-controller.js
+++ b/src/controllers/herbarios-controller.js
@@ -187,11 +187,11 @@ export const editar = (request, response, next) => {
             };
 
             if (herbario.endereco_id === null) {
-                const endereço = await Endereco.create(endereco, { transaction });
+                const localizacao = await Endereco.create(endereco, { transaction });
 
                 const dados = {
                     ...request.body.herbario,
-                    endereco_id: endereço.id,
+                    endereco_id: localizacao.id,
                 };
 
                 return herbario.update(dados, { transaction });

--- a/src/controllers/herbarios-controller.js
+++ b/src/controllers/herbarios-controller.js
@@ -175,7 +175,7 @@ export const editar = (request, response, next) => {
 
             return Herbario.findOne({ attributes, where, transaction });
         })
-        .then(herbario => {
+        .then(async herbario => {
             if (!herbario) {
                 throw new NotFoundExeption(200);
             }
@@ -186,11 +186,20 @@ export const editar = (request, response, next) => {
                 id: herbario.endereco_id,
             };
 
-            return Endereco.update(endereco, { where, transaction })
-                .then(() => herbario);
-        })
-        .then(herbario => {
+            if (herbario.endereco_id === null) {
+                const endereço = await Endereco.create(endereco, { transaction });
+
+                const dados = {
+                    ...request.body.herbario,
+                    endereco_id: endereço.id,
+                };
+
+                return herbario.update(dados, { transaction });
+            }
+
             const dados = omit(request.body.herbario, ['id', 'endereco_id']);
+
+            await Endereco.update(endereco, { where, transaction });
 
             return herbario.update(dados, { transaction })
                 .then(() => herbario);


### PR DESCRIPTION
# Description

Fixes the updating of herbaria by testing if the address_id is equal to null, it creates an address entity instead of updating it

## Type of change

- [x] Bug fix

# How Has This Been Tested?

- [x] Was tested via postman, editing a herbarium that already existed in the database and checking that the changes were saved
- [x] A new herbarium was created via the interface, then edited with other values and checked that the data was saved