### PR TITLE
fix(tombos-identificadores): ignore timestamp columns

### DIFF
--- a/src/models/TomboIdentificador.js
+++ b/src/models/TomboIdentificador.js
@@ -26,6 +26,7 @@ export default (Sequelize, DataTypes) => {
     const options = {
         defaultScope,
         freezeTableName: true,
+        timestamps: false,
     };
 
     const Model = Sequelize.define('tombos_identificadores', attributes, options);


### PR DESCRIPTION
# Description

Removes the search for fields with timestamp from the query

## Type of change

- [x] Bug fix

# How Has This Been Tested?

- [x] Removed the timestamp columns from the tombo_identifiers table
- [x] Were searched for collection details via the interface and checked that it worked even without the timestamp columns