### PR TITLE
Remoção do campo reino_id de modelos de taxonomia

### DIFF
--- a/src/controllers/taxonomias-controller.js
+++ b/src/controllers/taxonomias-controller.js
@@ -286,9 +286,8 @@ export const cadastrarSubfamilia = (request, response, next) => {
 
             return familiaEncontrada;
         })
-        .then(familia => Subfamilia.create({ nome,
+        .then(Subfamilia.create({ nome,
             familia_id: familiaId,
-            reino_id: familia.reino_id,
         }, transaction));
     sequelize.transaction(callback)
         .then(subfamiliaCriado => {
@@ -476,9 +475,8 @@ export const cadastrarGenero = (request, response, next) => {
 
             return familiaEncontrada;
         })
-        .then(familia => Genero.create({ nome,
+        .then(Genero.create({ nome,
             familia_id: familiaId,
-            reino_id: familia.reino_id,
         }, transaction));
     sequelize.transaction(callback)
         .then(generoCriado => {
@@ -676,7 +674,6 @@ export const cadastrarEspecie = (request, response, next) => {
                 nome,
                 genero_id: generoId,
                 familia_id: genero.familia_id,
-                reino_id: genero.reino_id,
                 autor_id: autorId,
             },
             transaction
@@ -905,7 +902,6 @@ export const cadastrarSubespecie = (request, response, next) => {
             genero_id: especie.genero_id,
             especie_id: especieId,
             familia_id: especie.familia_id,
-            reino_id: especie.reino_id,
             autor_id: autorId,
         }, transaction));
     sequelize.transaction(callback)
@@ -1143,7 +1139,6 @@ export const cadastrarVariedade = (request, response, next) => {
                 genero_id: especie.genero_id,
                 especie_id: especieId,
                 familia_id: especie.familia_id,
-                reino_id: especie.reino_id,
                 autor_id: autorId,
             },
             transaction

--- a/src/controllers/tombos-controller.js
+++ b/src/controllers/tombos-controller.js
@@ -321,7 +321,7 @@ export const cadastro = (request, response, next) => {
                     jsonTombo = {
                         ...jsonTombo,
                         // eslint-disable-next-line max-len
-                        ...pick(taxonomia, ['nome_cientifico', 'variedade_id', 'especie_id', 'genero_id', 'familia_id', 'reino_id', 'sub_familia_id', 'sub_especie_id']),
+                        ...pick(taxonomia, ['nome_cientifico', 'variedade_id', 'especie_id', 'genero_id', 'familia_id', 'sub_familia_id', 'sub_especie_id']),
                     };
                 }
                 if (colecoesAnexas && colecoesAnexas.id) {
@@ -1399,7 +1399,6 @@ export const obterTombo = async (request, response, next) => {
                 Familia.findAll({
                     where: {
                         id: dadosTombo.familia?.id,
-                        reino_id: dadosTombo.reino?.id,
                     },
                 })
             )

--- a/src/models/Especie.js
+++ b/src/models/Especie.js
@@ -4,7 +4,6 @@ function associate(modelos) {
         Familia,
         Especie,
         Genero,
-        Reino,
     } = modelos;
 
     Especie.belongsTo(Autor, {
@@ -18,10 +17,6 @@ function associate(modelos) {
 
     Especie.belongsTo(Familia, {
         foreignKey: 'familia_id',
-    });
-
-    Especie.belongsTo(Reino, {
-        foreignKey: 'reino_id',
     });
 
 }
@@ -62,10 +57,6 @@ export default (Sequelize, DataTypes) => {
         autor_id: {
             type: DataTypes.INTEGER,
             allowNull: true,
-        },
-        reino_id: {
-            type: DataTypes.INTEGER,
-            allowNull: false,
         },
     };
 

--- a/src/models/Genero.js
+++ b/src/models/Genero.js
@@ -2,15 +2,10 @@ function associate(modelos) {
     const {
         Familia,
         Genero,
-        Reino,
     } = modelos;
 
     Genero.belongsTo(Familia, {
         foreignKey: 'familia_id',
-    });
-
-    Genero.belongsTo(Reino, {
-        foreignKey: 'reino_id',
     });
 }
 
@@ -40,10 +35,6 @@ export default (Sequelize, DataTypes) => {
             allowNull: true,
         },
         familia_id: {
-            type: DataTypes.INTEGER,
-            allowNull: false,
-        },
-        reino_id: {
             type: DataTypes.INTEGER,
             allowNull: false,
         },

--- a/src/models/Subespecie.js
+++ b/src/models/Subespecie.js
@@ -5,7 +5,6 @@ function associate(modelos) {
         Especie,
         Genero,
         Subespecie,
-        Reino,
     } = modelos;
 
     Subespecie.belongsTo(Autor, {
@@ -21,9 +20,6 @@ function associate(modelos) {
     Subespecie.belongsTo(Especie, {
         foreignKey: 'especie_id',
         as: 'especie',
-    });
-    Subespecie.belongsTo(Reino, {
-        foreignKey: 'reino_id',
     });
 }
 
@@ -67,10 +63,6 @@ export default (Sequelize, DataTypes) => {
         autor_id: {
             type: DataTypes.INTEGER,
             allowNull: true,
-        },
-        reino_id: {
-            type: DataTypes.INTEGER,
-            allowNull: false,
         },
     };
 

--- a/src/models/Subfamilia.js
+++ b/src/models/Subfamilia.js
@@ -3,7 +3,6 @@ function associate(modelos) {
         Autor,
         Familia,
         Subfamilia,
-        Reino,
     } = modelos;
 
     Subfamilia.belongsTo(Autor, {
@@ -13,10 +12,6 @@ function associate(modelos) {
 
     Subfamilia.belongsTo(Familia, {
         foreignKey: 'familia_id',
-    });
-
-    Subfamilia.belongsTo(Reino, {
-        foreignKey: 'reino_id',
     });
 }
 
@@ -46,10 +41,6 @@ export default (Sequelize, DataTypes) => {
             allowNull: true,
         },
         familia_id: {
-            type: DataTypes.INTEGER,
-            allowNull: false,
-        },
-        reino_id: {
             type: DataTypes.INTEGER,
             allowNull: false,
         },

--- a/src/models/Tombo.js
+++ b/src/models/Tombo.js
@@ -15,7 +15,6 @@ function associate(modelos) {
         ColecaoAnexa,
         Usuario,
         Alteracao,
-        Reino,
         // TomboColetor,
         Relevo,
         Remessa,
@@ -118,10 +117,6 @@ function associate(modelos) {
 
     Tombo.belongsTo(Familia, {
         foreignKey: 'familia_id',
-    });
-
-    Tombo.belongsTo(Reino, {
-        foreignKey: 'reino_id',
     });
 
     Tombo.belongsTo(Subfamilia, {
@@ -247,10 +242,6 @@ export default (Sequelize, DataTypes) => {
             allowNull: true,
         },
         familia_id: {
-            type: DataTypes.INTEGER,
-            allowNull: true,
-        },
-        reino_id: {
             type: DataTypes.INTEGER,
             allowNull: true,
         },

--- a/src/models/Variedade.js
+++ b/src/models/Variedade.js
@@ -5,7 +5,6 @@ function associate(modelos) {
         Especie,
         Genero,
         Variedade,
-        Reino,
     } = modelos;
 
     Variedade.belongsTo(Autor, {
@@ -21,9 +20,6 @@ function associate(modelos) {
     Variedade.belongsTo(Especie, {
         foreignKey: 'especie_id',
         as: 'especie',
-    });
-    Variedade.belongsTo(Reino, {
-        foreignKey: 'reino_id',
     });
 }
 
@@ -67,10 +63,6 @@ export default (Sequelize, DataTypes) => {
         autor_id: {
             type: DataTypes.INTEGER,
             allowNull: true,
-        },
-        reino_id: {
-            type: DataTypes.INTEGER,
-            allowNull: false,
         },
     };
 


### PR DESCRIPTION
- Remove a dependência de reino_id de todos os modelos, menos do modelo de Família.