### PR TITLE
Correção edição de tombo do identificador

### DIFF
--- a/src/routes/pendencias.js
+++ b/src/routes/pendencias.js
@@ -46,6 +46,8 @@ export default app => {
         .get([
             tokensMiddleware([
                 TIPOS_USUARIOS.CURADOR,
+                TIPOS_USUARIOS.OPERADOR,
+                TIPOS_USUARIOS.IDENTIFICADOR,
             ]),
             controller.verificaAlteracao,
         ]);

--- a/src/routes/usuarios.js
+++ b/src/routes/usuarios.js
@@ -146,6 +146,7 @@ export default app => {
             tokensMiddleware([
                 TIPOS_USUARIOS.CURADOR,
                 TIPOS_USUARIOS.OPERADOR,
+                TIPOS_USUARIOS.IDENTIFICADOR,
             ]),
             controller.obtemIdentificadores,
         ]);


### PR DESCRIPTION
- Não estava sendo possível alterar a taxonomia de um tombo sendo um identificador.

Como foi resolvido:
- Existiam duas rotas de get que eram necessárias para a tela funcionar corretamente que estava trancada apenas para permissão de curador, foi adicionado permissões para identificador e operador.