### PR TITLE
Alteração na permissão das rotas de coletor (curador) - Problemas no cadastro de tombo

### DIFF
--- a/src/routes/coletor.js
+++ b/src/routes/coletor.js
@@ -1,6 +1,6 @@
 import * as coletoresController from '../controllers/coletor-controller';
 import listagensMiddleware from '../middlewares/listagens-middleware';
-import tokensMiddleware from '../middlewares/tokens-middleware';
+import tokensMiddleware, { TIPOS_USUARIOS } from '../middlewares/tokens-middleware';
 import validacoesMiddleware from '../middlewares/validacoes-middleware';
 import atualizarColetorEsquema from '../validators/coletor-atualiza';
 import cadastrarColetorEsquema from '../validators/coletor-cadastro';
@@ -75,7 +75,7 @@ export default app => {
      *         $ref: '#/components/responses/InternalServerError'
      */
     app.route('/coletores').post([
-        tokensMiddleware(['CURADOR']),
+        tokensMiddleware([TIPOS_USUARIOS.CURADOR]),
         validacoesMiddleware(cadastrarColetorEsquema),
         coletoresController.cadastraColetor,
     ]);
@@ -121,7 +121,7 @@ export default app => {
      *         $ref: '#/components/responses/InternalServerError'
      */
     app.route('/coletores/:id').get([
-        tokensMiddleware(['CURADOR']),
+        tokensMiddleware([TIPOS_USUARIOS.CURADOR]),
         coletoresController.encontraColetor,
     ]);
 
@@ -199,7 +199,7 @@ export default app => {
      *         $ref: '#/components/responses/InternalServerError'
      */
     app.route('/coletores').get([
-        tokensMiddleware(['CURADOR']),
+        tokensMiddleware([TIPOS_USUARIOS.CURADOR]),
         validacoesMiddleware(listarColetoresEsquema),
         listagensMiddleware,
         coletoresController.listaColetores,
@@ -267,7 +267,7 @@ export default app => {
      *         $ref: '#/components/responses/InternalServerError'
      */
     app.route('/coletores/:id').put([
-        tokensMiddleware(['CURADOR']),
+        tokensMiddleware([TIPOS_USUARIOS.CURADOR]),
         validacoesMiddleware(atualizarColetorEsquema),
         coletoresController.atualizaColetor,
     ]);
@@ -299,7 +299,7 @@ export default app => {
      *         $ref: '#/components/responses/InternalServerError'
      */
     app.route('/coletores/:id').delete([
-        tokensMiddleware(['CURADOR']),
+        tokensMiddleware([TIPOS_USUARIOS.CURADOR]),
         validacoesMiddleware(desativarColetorEsquema),
         coletoresController.desativaColetor,
     ]);


### PR DESCRIPTION
Closes #118 

## Considerações
O cadastro das subfamilias estar retornando erro 500 se refere a coluna `reino_id`, que está sendo removida por outro integrante do projeto. Assim, para testar, removi a coluna e verifiquei se sua remoção resolve o problema, o que foi certificado. Após essa verificação, a coluna foi reinserida para não afetar o trabalho do outro dev.

O problema do reconhecimento do reino no form e o load infinito ao cadastrar variedades foram resolvidos no frontend. É importante destacar que, para testar as variedades, também precisei remover a coluna `reino_id` das tabelas `variedades` e `especies`.

O problema da permissão foi resolvida mudando o modelo de verificação do token para o modelo hoje usado. Assim:
Foi trocado:
```js
...
tokensMiddleware(['CURADOR'),
...
```
Por:
```js
...
tokensMiddleware([TIPOS_USUARIOS.CURADOR]),
...
```
Em todas as rotas /coletores

Aparentemente, resolvendo os problemas acima, o problema de salvamento dos coletores e do reino no cadastro de tombos também foi resolvido.