### PR TITLE
fix: muda tabela de findAll para identificadores

### DIFF
--- a/src/controllers/usuarios-controller.js
+++ b/src/controllers/usuarios-controller.js
@@ -6,7 +6,7 @@ import models from '../models';
 import codigos from '../resources/codigos-http';
 
 const {
-    Sequelize: { Op }, Usuario, TipoUsuario, Coletor,
+    Sequelize: { Op }, Usuario, TipoUsuario, Coletor, Identificador,
 } = models;
 
 export const encontraUsuarioAtivoPorEmail = email => {
@@ -262,11 +262,10 @@ export const obtemIdentificadores = (request, response, next) => {
     const { nome } = request.query;
 
     Promise.resolve()
-        .then(() => Usuario.findAll({
+        .then(() => Identificador.findAll({
             attributes: ['id', 'nome'],
             order: [['nome', 'ASC']],
             where: {
-                ativo: true,
                 nome: { [Op.like]: `%${nome}%` },
             },
             limit: 10,

--- a/src/routes/identificador.js
+++ b/src/routes/identificador.js
@@ -1,6 +1,6 @@
 import * as identificadoresController from '../controllers/identificador-controller';
 import listagensMiddleware from '../middlewares/listagens-middleware';
-import tokensMiddleware from '../middlewares/tokens-middleware';
+import tokensMiddleware, { TIPOS_USUARIOS } from '../middlewares/tokens-middleware';
 import validacoesMiddleware from '../middlewares/validacoes-middleware';
 import atualizarIdentificadorEsquema from '../validators/identificador-atualiza';
 import cadastrarIdentificadorEsquema from '../validators/identificador-cadastro';
@@ -62,7 +62,7 @@ export default app => {
      *         $ref: '#/components/responses/InternalServerError'
      */
     app.route('/identificadores').post([
-        tokensMiddleware(['CURADOR']),
+        tokensMiddleware([TIPOS_USUARIOS.CURADOR]),
         validacoesMiddleware(cadastrarIdentificadorEsquema),
         identificadoresController.cadastraIdentificador,
     ]);
@@ -103,7 +103,7 @@ export default app => {
      *         $ref: '#/components/responses/InternalServerError'
      */
     app.route('/identificadores/:id').get([
-        tokensMiddleware(['CURADOR']),
+        tokensMiddleware([TIPOS_USUARIOS.CURADOR]),
         listagensMiddleware,
         identificadoresController.encontradaIdentificador,
     ]);
@@ -167,7 +167,7 @@ export default app => {
      *         $ref: '#/components/responses/InternalServerError'
      */
     app.route('/identificadores').get([
-        tokensMiddleware(['CURADOR']),
+        tokensMiddleware([TIPOS_USUARIOS.CURADOR]),
         validacoesMiddleware(listarIdentificadoresEsquema),
         listagensMiddleware,
         identificadoresController.listaIdentificadores,
@@ -225,7 +225,7 @@ export default app => {
      *         $ref: '#/components/responses/InternalServerError'
      */
     app.route('/identificadores/:id').put([
-        tokensMiddleware(['CURADOR']),
+        tokensMiddleware([TIPOS_USUARIOS.CURADOR]),
         validacoesMiddleware(atualizarIdentificadorEsquema),
         identificadoresController.atualizaIdentificador,
     ]);


### PR DESCRIPTION
## O que foi feito

Closes #134 

Erro de requisição para a tabela errada foi corrigida nesse PR.

Ainda, ao testar foi verificado que o usuário do tipo curador não tinha permissões necessárias para a rota de criação, listagem, atualização e obtenção por id com as validações antigas. Assim, foi mudado para o novo método e o problema foi corrigido.