### PR TITLE
fix: arruma visualizacao da ficha tombo

### DIFF
--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -43,6 +43,12 @@ export default function fichaTomboController(request, response, next) {
     const { tombo_id: tomboId } = request.params;
     const { qtd } = request.query;
 
+    if (qtd < 1) {
+        Promise.reject(new Error('Quantidade inválida'));
+    } else if (qtd > 3) {
+        Promise.reject(new Error('Quantidade máxima de 3 itens excedida'));
+    }
+
     Promise.resolve()
         .then(() => {
             const include = [
@@ -97,7 +103,7 @@ export default function fichaTomboController(request, response, next) {
                     model: LocalColeta,
                     include: [
                         {
-                            required: true,
+                            required: false,
                             model: Cidade,
                             include: {
                                 required: true,
@@ -123,10 +129,11 @@ export default function fichaTomboController(request, response, next) {
 
             const where = {
                 ativo: true,
-                hcf: tomboId,
+                hcf: parseInt(tomboId),
             };
 
-            return Tombo.findOne({ include, where });
+            const tombo = Tombo.findOne({ include, where });
+            return tombo;
         })
         .then(tombo => {
             if (!tombo) {
@@ -197,9 +204,9 @@ export default function fichaTomboController(request, response, next) {
             const coletores = `${tombo.coletore.nome}${tombo.coletor_complementar ? tombo.coletor_complementar.complementares : ''}`;
 
             const localColeta = tombo.local_coleta;
-            const { cidade } = localColeta;
-            const { estado } = cidade;
-            const { pais } = estado;
+            const cidade = localColeta.cidade || '';
+            const estado = cidade?.estado || '';
+            const pais = estado?.pais || '';
 
             const romanos = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX', 'X', 'XI', 'XII'];
             const dataTombo = new Date(tombo.data_tombo);


### PR DESCRIPTION
Closes #154 

## O que foi feito
Foi adicionado um validador da quantidade de cópias, já que não deve ser possível gerar ficha para mais de 3 cópias (e para números negativos)

Se o problema de exibição for o mesmo que ocorreu em desenvolvimento, se refere ao fato de alguns locais de coleta não possuirem cidades/estado (o que é estranho pois antes as fichas estavam sendo mostradas corretamente).
