### PR TITLE
Feat/161 ajusta ficha tombo para pedir codigo barras

### DIFF
--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -41,7 +41,7 @@ function formataDataSaida(data) {
 
 export default function fichaTomboController(request, response, next) {
     const { tombo_id: tomboId } = request.params;
-    const { qtd } = request.query;
+    const { qtd, code } = request.query;
 
     if (qtd < 1) {
         Promise.reject(new Error('Quantidade inválida'));
@@ -259,6 +259,7 @@ export default function fichaTomboController(request, response, next) {
                 romano_data_identificacao: romanoDataIdentificacao,
                 romano_data_coleta: romanoDataColeta,
                 numero_copias: qtd || 1,
+                codigo_barras_selecionado: code,
             };
 
             const caminhoArquivoHtml = path.resolve(__dirname, '../views/ficha-tombo.ejs');

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -228,7 +228,7 @@
     <script>
         window.addEventListener('load', () => {
             const id = "<%- '#code128_' + fotos[i]['id'] %>";
-            const cbarra = "<%- fotos[i]['codigo_barra'] %>";
+            const cbarra = "<%- codigo_barras_selecionado %>";
             JsBarcode(id, cbarra, { margin: 0, width: 1.4, height: 40, fontSize: 10 });
         });
     </script>


### PR DESCRIPTION
## O que foi feito

Closes utfpr/hcf-painel#164 #161 

Esse PR contempla:
- A adição de uma url query denominada `code` para informar o código de barras selecionado no frontend
- A informação do novo dado para a função responsável pela geração da imagem do código de barras