### PR TITLE
fix: corrige ficha tombo para tombos especificos

### DIFF
--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -240,7 +240,7 @@ export default function fichaTomboController(request, response, next) {
                 familia: tombo.familia,
                 imprimir: request.params.imprimir_cod,
 
-                identificador: tombo.identificadores[0].nome,
+                identificador: tombo.identificadores?.[0]?.nome,
                 identificacao: {
                     ...identificacao,
                     data_identificacao: formataColunasSeparadas(


### PR DESCRIPTION
Closes #181 

## O que foi feito
Campos que eram obrigatórios agora são opcionais. Essa mudança faz com que os tombos que estavam com problemas na ficha tombo, agora consigam ter a sua ficha gerada.