### PR TITLE
fix: realiza ajustes na ficha tombo para utilização do software

### DIFF
--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -211,8 +211,9 @@ export default function fichaTomboController(request, response, next) {
             const romanos = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX', 'X', 'XI', 'XII'];
             const dataTombo = new Date(tombo.data_tombo);
             const romanoDataTombo = (`${dataTombo.getDate()}/${romanos[dataTombo.getMonth()]}/${dataTombo.getFullYear()}`);
+            const dataIdentificacao = new Date(identificacao.created_at);
             // eslint-disable-next-line max-len
-            const romanoDataIdentificacao = (`${identificacao.data_identificacao_dia}/${romanos[identificacao.data_identificacao_mes - 1]}/${identificacao.data_identificacao_ano}`);
+            const romanoDataIdentificacao = (`${dataIdentificacao.getDate()}/${romanos[dataIdentificacao.getMonth()]}/${dataIdentificacao.getFullYear()}`);
             const romanoDataColeta = (`${tombo.data_coleta_dia}/${romanos[tombo.data_coleta_mes - 1]}/${tombo.data_coleta_ano}`);
 
             const parametros = {

--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -217,7 +217,7 @@ export default function fichaTomboController(request, response, next) {
             const { tombo, identificacao, fotos } = resultado;
 
             // eslint-disable-next-line max-len
-            const coletores = `${!!tombo?.coletore?.nome !== false ? tombo?.coletore?.nome : ''}${tombo?.coletor_complementar ? tombo.coletor_complementar?.complementares : ''}`;
+            const coletores = `${!!tombo?.coletore?.nome !== false ? tombo?.coletore?.nome?.concat(' ') : ''}${tombo?.coletor_complementar ? tombo.coletor_complementar?.complementares : ''}`;
 
             const localColeta = tombo.local_coleta;
             const cidade = localColeta.cidade || '';

--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -229,16 +229,16 @@ export default function fichaTomboController(request, response, next) {
             const romanoDataTombo = (`${dataTombo.getDate()}/${romanos[dataTombo.getMonth()]}/${dataTombo.getFullYear()}`);
 
             const jsonParaIdentificacao = parseJsonSafe(identificacao?.tombo_json);
-            const identificador = tombo.identificadores?.[0]?.nome || '';
+            const identificador = tombo.identificadores?.[0]?.nome &&
+              tombo.identificadores?.[0]?.nome.toLowerCase() !== 'não-identificado' ?
+                tombo.identificadores?.[0]?.nome : '' || '';
 
-            let temDataIdentificacao = !jsonParaIdentificacao && false;
             const romanoDataIdentificacao = formataDataIdentificacao(
                 jsonParaIdentificacao?.data_identificacao_dia,
                 jsonParaIdentificacao?.data_identificacao_mes,
                 jsonParaIdentificacao?.data_identificacao_ano,
                 romanos
             );
-            temDataIdentificacao = romanoDataIdentificacao !== '';
 
             // eslint-disable-next-line max-len
             const romanoDataColeta = (`${tombo.data_coleta_dia}/${romanos[tombo.data_coleta_mes - 1]}/${tombo.data_coleta_ano}`);
@@ -289,7 +289,6 @@ export default function fichaTomboController(request, response, next) {
                 romano_data_tombo: romanoDataTombo,
 
                 romano_data_identificacao: romanoDataIdentificacao, // Data de identificação. Se não existir, será uma string vazia
-                tem_data_identificacao: temDataIdentificacao, // Chave que diz se a data de identificação existe e deve ser exibida
 
                 numero_copias: qtd || 1,
                 codigo_barras_selecionado: code,

--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -229,6 +229,8 @@ export default function fichaTomboController(request, response, next) {
             const romanoDataTombo = (`${dataTombo.getDate()}/${romanos[dataTombo.getMonth()]}/${dataTombo.getFullYear()}`);
 
             const jsonParaIdentificacao = parseJsonSafe(identificacao?.tombo_json);
+            const identificador = tombo.identificadores?.[0]?.nome || '';
+
             let temDataIdentificacao = !jsonParaIdentificacao && false;
             const romanoDataIdentificacao = formataDataIdentificacao(
                 jsonParaIdentificacao?.data_identificacao_dia,
@@ -266,7 +268,7 @@ export default function fichaTomboController(request, response, next) {
                 familia: tombo.familia,
                 imprimir: request.params.imprimir_cod,
 
-                identificador: tombo.identificadores?.[0]?.nome,
+                identificador,
                 identificacao: {
                     ...identificacao,
                     data_identificacao: formataColunasSeparadas(

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -209,12 +209,17 @@
         </tr>
         <tr>
             <td colspan="2">
-                <b style="font-size: 14px;"><%- tombo.coletores.length == 1 ? 'Coletor' : 'Coletores' %>:</b> <%- tombo.coletores %>
+              <div style="display: flex; gap: 5px;">
+                <b style="font-size: 14px;"><%- tombo.coletores.length == 1 ? 'Coletor' : 'Coletores' %>:</b>
+                <div>
+                  <%- tombo.coletores %>
+                </div>
+              </div>
             </td>
-            <td width="20%" class="text-right">
+            <td width="19%" class="text-right" style="text-align:right; vertical-align:top;">
                 <b>nº:</b> <%- tombo.numero_coleta %>
             </td>
-            <td width="21%" class="text-right">
+            <td width="21%" class="text-right" style="text-align:right; vertical-align:top;">
                 <b>Data:</b> <%- romano_data_coleta %>
             </td>
         </tr>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -137,18 +137,14 @@
                 <b style="font-size: 14px;">Nome Vulgar:</b> <%- tombo.nomes_populares %>
             </td>
         </tr>
-        <% if (identificacao) { %>
         <tr>
-            <td colspan="3">
-                <b style="font-size: 14px;">Identificador:</b> <%- identificador %>
-            </td>
-            <td>
-                <% if (tem_data_identificacao) { %>
-                  <b style="font-size: 14px;">Data:</b> <%- romano_data_identificacao %>
-                <% } %>
-            </td>
+          <td colspan="3">
+              <b style="font-size: 14px;">Identificador:</b> <%- identificador %>
+          </td>
+          <td>
+            <b style="font-size: 14px;">Data:</b> <%- romano_data_identificacao %>
+          </td>
         </tr>
-        <% } %>
         <tr>
             <td colspan="4">
                 <b style="font-size: 14px;">Local de coleta:</b>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -175,8 +175,8 @@
         <tr>
             <td colspan="4">
                 <b style="font-size: 14px;">Observações:</b> 
-                <% if (tombo && tombo.observacao) { %>
-                    <%- tombo.observacao %>
+                <% if (tombo && tombo.descricao) { %>
+                    <%- tombo.descricao %>
                 <% } %>
                 <% if (tombo && tombo.latitude) { %>
                     - Latitude: <%- tombo.latitude %>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -137,10 +137,10 @@
                 <b style="font-size: 14px;">Nome Vulgar:</b> <%- tombo.nomes_populares %>
             </td>
         </tr>
-        <% if (identificacao && identificacao.usuario) { %>
+        <% if (identificacao) { %>
         <tr>
             <td colspan="3">
-                <b style="font-size: 14px;">Identificador:</b> <%- identificacao.usuario.nome %>
+                <b style="font-size: 14px;">Identificador:</b> <%- identificador %>
             </td>
             <td>
                 <% if (tem_data_identificacao) { %>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -143,7 +143,9 @@
                 <b style="font-size: 14px;">Identificador:</b> <%- identificacao.usuario.nome %>
             </td>
             <td>
-                <b style="font-size: 14px;">Data:</b> <%- romano_data_identificacao %>
+                <% if (tem_data_identificacao) { %>
+                  <b style="font-size: 14px;">Data:</b> <%- romano_data_identificacao %>
+                <% } %>
             </td>
         </tr>
         <% } %>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -185,7 +185,7 @@
                     - Longitude: <%- tombo.longitude %>
                 <% } %>
                 <% if (tombo && tombo.altitude) { %>
-                    - Altitude: <%- tombo.altitude %>
+                    - Altitude: <%- tombo.altitude %>m
                 <% } %>
                 <% if (localColeta && localColeta.solo) { %>
                     - Solo: <%- localColeta.solo.nome %>


### PR DESCRIPTION
Closes #189 

## O que foi feito
Na ficha tombo foram realizados os seguintes ajustes:
- Data de identificação corrigida;
- Nome do identificador corrigido;
- Aumenta espaço da informação de coletores;
- Concatena coletor principal e demais com espaço;
- Em caso de quebra de linha, os coletores da próxima linha são exibidos abaixo do primeiro coletor;
- Adiciona unidade de medida metros (m) sem espaço na informação de altitude;
- Exibe o campo descricao do tombo na informação Observações;
- Em caso de não existência de data de identificação e/ou identificador, os rótulos são exibidos mesmo que sem valores;