### PR TITLE
fix: Exibe datas parciais e retira dependencia do campo descrição para exibição da data de identificação

### DIFF
--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -211,8 +211,9 @@ export default function fichaTomboController(request, response, next) {
             const romanos = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX', 'X', 'XI', 'XII'];
             const dataTombo = new Date(tombo.data_tombo);
             const romanoDataTombo = (`${dataTombo.getDate()}/${romanos[dataTombo.getMonth()]}/${dataTombo.getFullYear()}`);
+            const dataIdentificacao = new Date(identificacao.created_at);
             // eslint-disable-next-line max-len
-            const romanoDataIdentificacao = (`${identificacao.data_identificacao_dia}/${romanos[identificacao.data_identificacao_mes - 1]}/${identificacao.data_identificacao_ano}`);
+            const romanoDataIdentificacao = (`${dataIdentificacao.getDate()}/${romanos[dataIdentificacao.getMonth()]}/${dataIdentificacao.getFullYear()}`);
             const romanoDataColeta = (`${tombo.data_coleta_dia}/${romanos[tombo.data_coleta_mes - 1]}/${tombo.data_coleta_ano}`);
 
             const parametros = {

--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -217,7 +217,7 @@ export default function fichaTomboController(request, response, next) {
             const { tombo, identificacao, fotos } = resultado;
 
             // eslint-disable-next-line max-len
-            const coletores = `${!!tombo?.coletore?.nome !== false ? tombo?.coletore?.nome : ''}${tombo?.coletor_complementar ? tombo.coletor_complementar?.complementares : ''}`;
+            const coletores = `${!!tombo?.coletore?.nome !== false ? tombo?.coletore?.nome?.concat(' ') : ''}${tombo?.coletor_complementar ? tombo.coletor_complementar?.complementares : ''}`;
 
             const localColeta = tombo.local_coleta;
             const cidade = localColeta.cidade || '';

--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -229,16 +229,16 @@ export default function fichaTomboController(request, response, next) {
             const romanoDataTombo = (`${dataTombo.getDate()}/${romanos[dataTombo.getMonth()]}/${dataTombo.getFullYear()}`);
 
             const jsonParaIdentificacao = parseJsonSafe(identificacao?.tombo_json);
-            const identificador = tombo.identificadores?.[0]?.nome || '';
+            const identificador = tombo.identificadores?.[0]?.nome &&
+              tombo.identificadores?.[0]?.nome.toLowerCase() !== 'não-identificado' ?
+                tombo.identificadores?.[0]?.nome : '' || '';
 
-            let temDataIdentificacao = !jsonParaIdentificacao && false;
             const romanoDataIdentificacao = formataDataIdentificacao(
                 jsonParaIdentificacao?.data_identificacao_dia,
                 jsonParaIdentificacao?.data_identificacao_mes,
                 jsonParaIdentificacao?.data_identificacao_ano,
                 romanos
             );
-            temDataIdentificacao = romanoDataIdentificacao !== '';
 
             // eslint-disable-next-line max-len
             const romanoDataColeta = (`${tombo.data_coleta_dia}/${romanos[tombo.data_coleta_mes - 1]}/${tombo.data_coleta_ano}`);
@@ -289,7 +289,6 @@ export default function fichaTomboController(request, response, next) {
                 romano_data_tombo: romanoDataTombo,
 
                 romano_data_identificacao: romanoDataIdentificacao, // Data de identificação. Se não existir, será uma string vazia
-                tem_data_identificacao: temDataIdentificacao, // Chave que diz se a data de identificação existe e deve ser exibida
 
                 numero_copias: qtd || 1,
                 codigo_barras_selecionado: code,

--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -40,22 +40,23 @@ function formataDataSaida(data) {
 }
 
 function formataDataIdentificacao(dia, mes, ano, arrayRomanos) {
-    if (!dia || !mes || !ano) {
+    // Se não tiver ano, não mostra nada
+    if (!ano) {
         return '';
     }
-    return `${dia}/${arrayRomanos[mes - 1]}/${ano}`;
-}
 
-function parseJsonSafe(str) {
-    try {
-        const parsed = JSON.parse(str);
-        if (parsed && typeof parsed === 'object') {
-            return parsed; // existe e é um objeto/array
-        }
-        return null; // pode ser null, number, string etc.
-    } catch {
-        return null; // inválido
+    // Se tiver mês e ano mas não tiver dia, mostra mês/ano
+    if (!dia && mes && ano) {
+        return `${arrayRomanos[mes - 1]}/${ano}`;
     }
+
+    // Se não tiver mês mas tiver ano, mostra só o ano
+    if (!mes && ano) {
+        return `${ano}`;
+    }
+
+    // Se tiver dia, mês e ano, mostra tudo
+    return `${dia}/${arrayRomanos[mes - 1]}/${ano}`;
 }
 
 export default function fichaTomboController(request, response, next) {
@@ -228,16 +229,14 @@ export default function fichaTomboController(request, response, next) {
             const dataTombo = new Date(tombo.data_tombo);
             const romanoDataTombo = (`${dataTombo.getDate()}/${romanos[dataTombo.getMonth()]}/${dataTombo.getFullYear()}`);
 
-            const jsonParaIdentificacao = parseJsonSafe(identificacao?.tombo_json);
-
             const identificador = tombo.identificadores?.[0]?.nome &&
               tombo.identificadores?.[0]?.nome.toLowerCase() !== 'não-identificado' ?
                 tombo.identificadores?.[0]?.nome : '' || '';
 
             const romanoDataIdentificacao = formataDataIdentificacao(
-                jsonParaIdentificacao?.data_identificacao_dia,
-                jsonParaIdentificacao?.data_identificacao_mes,
-                jsonParaIdentificacao?.data_identificacao_ano,
+                tombo?.data_identificacao_dia,
+                tombo?.data_identificacao_mes,
+                tombo?.data_identificacao_ano,
                 romanos
             );
 

--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -229,6 +229,8 @@ export default function fichaTomboController(request, response, next) {
             const romanoDataTombo = (`${dataTombo.getDate()}/${romanos[dataTombo.getMonth()]}/${dataTombo.getFullYear()}`);
 
             const jsonParaIdentificacao = parseJsonSafe(identificacao?.tombo_json);
+            const identificador = tombo.identificadores?.[0]?.nome || '';
+
             let temDataIdentificacao = !jsonParaIdentificacao && false;
             const romanoDataIdentificacao = formataDataIdentificacao(
                 jsonParaIdentificacao?.data_identificacao_dia,
@@ -266,7 +268,7 @@ export default function fichaTomboController(request, response, next) {
                 familia: tombo.familia,
                 imprimir: request.params.imprimir_cod,
 
-                identificador: tombo.identificadores?.[0]?.nome,
+                identificador,
                 identificacao: {
                     ...identificacao,
                     data_identificacao: formataColunasSeparadas(

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -209,12 +209,17 @@
         </tr>
         <tr>
             <td colspan="2">
-                <b style="font-size: 14px;"><%- tombo.coletores.length == 1 ? 'Coletor' : 'Coletores' %>:</b> <%- tombo.coletores %>
+              <div style="display: flex; gap: 5px;">
+                <b style="font-size: 14px;"><%- tombo.coletores.length == 1 ? 'Coletor' : 'Coletores' %>:</b>
+                <div>
+                  <%- tombo.coletores %>
+                </div>
+              </div>
             </td>
-            <td width="20%" class="text-right">
+            <td width="19%" class="text-right" style="text-align:right; vertical-align:top;">
                 <b>nº:</b> <%- tombo.numero_coleta %>
             </td>
-            <td width="21%" class="text-right">
+            <td width="21%" class="text-right" style="text-align:right; vertical-align:top;">
                 <b>Data:</b> <%- romano_data_coleta %>
             </td>
         </tr>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -137,18 +137,14 @@
                 <b style="font-size: 14px;">Nome Vulgar:</b> <%- tombo.nomes_populares %>
             </td>
         </tr>
-        <% if (identificacao) { %>
         <tr>
-            <td colspan="3">
-                <b style="font-size: 14px;">Identificador:</b> <%- identificador %>
-            </td>
-            <td>
-                <% if (tem_data_identificacao) { %>
-                  <b style="font-size: 14px;">Data:</b> <%- romano_data_identificacao %>
-                <% } %>
-            </td>
+          <td colspan="3">
+              <b style="font-size: 14px;">Identificador:</b> <%- identificador %>
+          </td>
+          <td>
+            <b style="font-size: 14px;">Data:</b> <%- romano_data_identificacao %>
+          </td>
         </tr>
-        <% } %>
         <tr>
             <td colspan="4">
                 <b style="font-size: 14px;">Local de coleta:</b>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -175,8 +175,8 @@
         <tr>
             <td colspan="4">
                 <b style="font-size: 14px;">Observações:</b> 
-                <% if (tombo && tombo.observacao) { %>
-                    <%- tombo.observacao %>
+                <% if (tombo && tombo.descricao) { %>
+                    <%- tombo.descricao %>
                 <% } %>
                 <% if (tombo && tombo.latitude) { %>
                     - Latitude: <%- tombo.latitude %>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -137,10 +137,10 @@
                 <b style="font-size: 14px;">Nome Vulgar:</b> <%- tombo.nomes_populares %>
             </td>
         </tr>
-        <% if (identificacao && identificacao.usuario) { %>
+        <% if (identificacao) { %>
         <tr>
             <td colspan="3">
-                <b style="font-size: 14px;">Identificador:</b> <%- identificacao.usuario.nome %>
+                <b style="font-size: 14px;">Identificador:</b> <%- identificador %>
             </td>
             <td>
                 <% if (tem_data_identificacao) { %>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -143,7 +143,9 @@
                 <b style="font-size: 14px;">Identificador:</b> <%- identificacao.usuario.nome %>
             </td>
             <td>
-                <b style="font-size: 14px;">Data:</b> <%- romano_data_identificacao %>
+                <% if (tem_data_identificacao) { %>
+                  <b style="font-size: 14px;">Data:</b> <%- romano_data_identificacao %>
+                <% } %>
             </td>
         </tr>
         <% } %>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -185,7 +185,7 @@
                     - Longitude: <%- tombo.longitude %>
                 <% } %>
                 <% if (tombo && tombo.altitude) { %>
-                    - Altitude: <%- tombo.altitude %>
+                    - Altitude: <%- tombo.altitude %>m
                 <% } %>
                 <% if (localColeta && localColeta.solo) { %>
                     - Solo: <%- localColeta.solo.nome %>


### PR DESCRIPTION
Closes #189 

## O que foi feito
Adaptei a função que formata a data de identificação para mostrar as datas de identificação parciais como mencionadas pelo prof. @andreschwerz. Pode-se observar nas imagens abaixo que:
- O tombo 28 possui o mês e o ano na data de identificação;
- O tombo 29 só possui o ano na data de identificação;
- O tombo 214 não possui nem mês nem ano, portanto a data de identificação não foi exibida;
- O tombo 42844 não possui identificação, assim não foi exibido identificador nem sua respectiva data;
- O tombo 42806 possui identificador e data de identificação completas, mostrando assim os valores nas devidas chaves;<br/>
 
Ainda  foi retirada a dependência de haver a informação da descrição para exibição da data de identificação. Aparentemente isso era causado pois a `tombo_json` só era devolvido quando determinados valores eram preenchidos e, como anteriormente as chaves que formavam a data eram retirados dele, a data não era exibida. Agora, os valores que compõem a data são puxados diretamente do tombo.<br/>

## Anexos
<img width="547" height="357" alt="Screenshot 2025-09-05 at 19 46 59" src="https://github.com/user-attachments/assets/50d7ecdb-b50e-442f-9930-a873bc46f0ff" />
<img width="546" height="353" alt="Screenshot 2025-09-05 at 19 47 21" src="https://github.com/user-attachments/assets/c8cab1d8-6e09-454a-8ebf-73582b156891" />
<img width="544" height="356" alt="Screenshot 2025-09-05 at 19 48 00" src="https://github.com/user-attachments/assets/5f47c78e-f49b-48a3-8c6e-dfe2cf38b23b" />
<img width="545" height="358" alt="Screenshot 2025-09-05 at 19 51 54" src="https://github.com/user-attachments/assets/078ea224-263c-4447-bd58-8fe8db7a2855" />
<img width="546" height="353" alt="Screenshot 2025-09-05 at 19 52 15" src="https://github.com/user-attachments/assets/03d39f56-a810-4e12-8862-76d12532eaa5" /> 
