### PR TITLE
Remover coluna numero da tabela de coletores e adicionar index na tabela de tombos

### DIFF
--- a/src/controllers/coletor-controller.js
+++ b/src/controllers/coletor-controller.js
@@ -6,14 +6,6 @@ const { Coletor, Sequelize: { Op } } = models;
 
 export const cadastraColetor = async (req, res, next) => {
     try {
-        if (req.body.numero) {
-            const validaNumero = await Coletor.findOne({
-                where: { numero: req.body.numero },
-            });
-
-            if (validaNumero) return res.status(400).json({ mensagem: 'Número do coletor já está em uso.' });
-        }
-
         const coletor = await Coletor.create(req.body);
 
         res.status(codigos.CADASTRO_RETORNO).json(coletor);

--- a/src/controllers/pendencias-controller.js
+++ b/src/controllers/pendencias-controller.js
@@ -1463,15 +1463,6 @@ export const aprovarPendencia = async (alteracao, hcf, transaction) => {
                 throw new BadRequestExeption(404);
             }
 
-            const numeroColeta = updateTombo.numero_coleta;
-            if (numeroColeta && coletor.numero && coletor.numero < numeroColeta) {
-                await Coletor.update({
-                    numero: numeroColeta,
-                }, {
-                    where: { id: alteracao.coletor_id },
-                    transaction,
-                });
-            }
         }
         updateTombo.coletor_id = alteracao.coletor_id;
     }

--- a/src/controllers/tombos-controller.js
+++ b/src/controllers/tombos-controller.js
@@ -909,7 +909,6 @@ export const cadastrarColetores = (request, response, next) => {
             where: {
                 nome: request.body.nome,
                 email: request.body.email,
-                numero: request.body.numero,
             },
             transaction,
         }))
@@ -921,7 +920,6 @@ export const cadastrarColetores = (request, response, next) => {
         .then(() => Coletor.create({
             nome: request.body.nome,
             email: request.body.email,
-            numero: request.body.numero,
         }, transaction));
     sequelize.transaction(callback)
         .then(coletor => {
@@ -962,23 +960,6 @@ export const buscarColetores = (request, response, next) => {
                 throw new BadRequestExeption(415);
             }
             response.status(codigos.LISTAGEM).json(coletores.rows);
-        })
-        .catch(next);
-};
-
-export const buscarProximoNumeroColetor = (request, response, next) => {
-    Promise.resolve()
-        .then(() => Coletor.findAndCountAll({
-            attributes: ['id', 'nome', 'email', 'numero'],
-            order: [['numero', 'DESC']],
-        }))
-        .then(coletores => {
-            if (!coletores) {
-                throw new BadRequestExeption(214);
-            }
-            response.status(codigos.LISTAGEM).json({
-                numero: coletores.rows[0].numero + 1,
-            });
         })
         .catch(next);
 };

--- a/src/database/migration/20250911200431_rem-numero-coletor.ts
+++ b/src/database/migration/20250911200431_rem-numero-coletor.ts
@@ -1,0 +1,11 @@
+import { Knex } from 'knex'
+
+export async function run(knex: Knex): Promise<void> {
+  await knex.schema.table('coletores', table => {
+    table.dropColumn('numero')
+  })
+
+  await knex.schema.table('tombos', table => {
+    table.index(['coletor_id', 'numero_coleta'], 'idx_tombos_coletor_id_numero_coleta')
+  })
+}

--- a/src/models/Coletor.js
+++ b/src/models/Coletor.js
@@ -26,10 +26,6 @@ export default (Sequelize, DataTypes) => {
             type: DataTypes.STRING(200),
             allowNull: true,
         },
-        numero: {
-            type: DataTypes.INTEGER,
-            allowNull: true,
-        },
         ativo: {
             type: DataTypes.BOOLEAN,
             allowNull: true,

--- a/src/routes/tombos.js
+++ b/src/routes/tombos.js
@@ -6,7 +6,7 @@ import fichaTomboController from '../controllers/fichas-tombos-controller';
 import {
     getDadosCadTombo, getNumeroTombo, cadastro, listagem,
     desativar, obterTombo, cadastrarTipo, buscarTipos, cadastrarColetores, buscarColetores,
-    buscarProximoNumeroColetor, alteracao, getNumeroColetor, getUltimoNumeroTombo, getCodigoBarraTombo,
+    alteracao, getNumeroColetor, getUltimoNumeroTombo, getCodigoBarraTombo,
     editarCodigoBarra, getUltimoNumeroCodigoBarras, postCodigoBarraTombo,
     getUltimoCodigoBarra, deletarCodigoBarras,
 } from '../controllers/tombos-controller';
@@ -914,37 +914,6 @@ export default app => {
         ])
         .get([
             buscarColetores,
-        ]);
-
-    /**
-     * @swagger
-     * /numero-coletores:
-     *   get:
-     *     summary: Obtém o próximo número de coletor
-     *     tags: [Tombos]
-     *     responses:
-     *       200:
-     *         description: Próximo número retornado com sucesso
-     *         content:
-     *           application/json:
-     *             schema:
-     *               type: object
-     *               properties:
-     *                 numero:
-     *                   type: integer
-     *       '401':
-     *         $ref: '#/components/responses/Unauthorized'
-     *       '403':
-     *         $ref: '#/components/responses/Forbidden'
-     *       '500':
-     *         $ref: '#/components/responses/InternalServerError'
-     */
-    app.route('/numero-coletores')
-        .get([
-            tokensMiddleware([
-                TIPOS_USUARIOS.CURADOR, TIPOS_USUARIOS.OPERADOR,
-            ]),
-            buscarProximoNumeroColetor,
         ]);
 
     /**


### PR DESCRIPTION
- Criação de migration para retirar a coluna 'numero' da tabela 'coletores' e criar index na tabela 'tombos' para coletor_id e numero_coleta.
- Apagado referências à coluna numero da tabela coletores em qualquer parte do código.