### PR TITLE
Fix/85 adiciona familia no topo da pagina de relatorio

### DIFF
--- a/src/controllers/locais-coleta-controller.js
+++ b/src/controllers/locais-coleta-controller.js
@@ -133,7 +133,7 @@ export const cadastrarLocalColeta = async (request, response, next) => {
 };
 
 export const buscarLocaisColeta = async (request, response, next) => {
-        try {
+    try {
         const cidadeId = request.query.cidade_id;
         const { limite, pagina, offset } = request.paginacao;
         const { getAll } = request.query;

--- a/src/controllers/pendencias-controller.js
+++ b/src/controllers/pendencias-controller.js
@@ -1135,7 +1135,7 @@ export const aprovarPendencia = async (alteracao, hcf, transaction) => {
         updateTombo.cor = alteracao.cor ? alteracao.cor.toUpperCase() : null;
     }
 
-    if(alteracao.data_tombo !== undefined){
+    if (alteracao.data_tombo !== undefined) {
         updateTombo.data_tombo = alteracao.data_tombo;
     }
 

--- a/src/controllers/tombos-controller.js
+++ b/src/controllers/tombos-controller.js
@@ -293,7 +293,7 @@ export const cadastro = (request, response, next) => {
                     cor: principal.cor,
                     coletor_id: coletor,
                     data_tombo: parseDataTombo(principal.data_tombo),
-                };  
+                };
 
                 if (paisagem?.descricao) {
                     jsonTombo.descricao = paisagem.descricao;
@@ -495,7 +495,7 @@ function alteracaoCuradorouOperador(request, response, transaction) {
     if (cor !== undefined) update.cor = cor;
 
     const dataTombo = body?.principal?.data_tombo;
-    if(dataTombo !== undefined) update.data_tombo = parseDataTombo(dataTombo);
+    if (dataTombo !== undefined) update.data_tombo = parseDataTombo(dataTombo);
 
     const familiaId = body?.taxonomia?.familia_id;
     if (familiaId !== undefined) update.familia_id = familiaId;
@@ -556,9 +556,9 @@ function alteracaoCuradorouOperador(request, response, transaction) {
     if (dataIdentificacao?.dia !== undefined) update.data_identificacao_dia = dataIdentificacao.dia;
     if (dataIdentificacao?.mes !== undefined) update.data_identificacao_mes = dataIdentificacao.mes;
     if (dataIdentificacao?.ano !== undefined) update.data_identificacao_ano = dataIdentificacao.ano;
-    if(dataIdentificacao === null) { 
-        update.data_identificacao_dia = null; 
-        update.data_identificacao_mes = null; 
+    if (dataIdentificacao === null) {
+        update.data_identificacao_dia = null;
+        update.data_identificacao_mes = null;
         update.data_identificacao_ano = null;
     }
 

--- a/src/reports/assets/styles/root.css
+++ b/src/reports/assets/styles/root.css
@@ -68,7 +68,7 @@ tfoot {
   margin-top: 0.625rem;
 }
 
-#grupoComBorda {
+.grupoComBorda {
   border: 1px solid #808080;
   padding: 2px; 
   margin-bottom: 10px;
@@ -77,46 +77,47 @@ tfoot {
   page-break-after: always;
 }
 
-#nomeGrupoContainer {
-  display: flex; 
+.nomeGrupoContainer {
   align-items: center; 
   justify-content: left; 
   background-color: #D3D3D3; 
-  padding: 5px; 
   border-radius: 5px;
+  width: 100%;
 }
 
-#nomeGrupo {
+.nomeGrupo {
   margin: 0; 
-  padding: 0; 
+  padding: 5px 10px; 
   font-weight: 500;
+  width: 100%;
+  font-size: 14px;
 }
 
-#tabelaComBordaSimples {
+.tabelaComBordaSimples {
   border-bottom: 2px solid #E4E4E4;
 }
 
-#col1 {
+.col1 {
   width: 30%;
   font-size: 14px;
 }
 
-#col2 {
+.col2 {
   width: 70%;
   font-size: 14px;
 }
 
-#grupoLocalColeta {
+.grupoLocalColeta {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
-#grupoLocalColeta div {
+.grupoLocalColeta div {
   width: calc(33%); /* 33% menos 2.5rem de espaçamento das margens */
 }
 
-#grupoLocalColeta div h1 {
+.grupoLocalColeta div h1 {
   white-space: nowrap;         /* impede quebra de linha */
   overflow: hidden;            /* esconde o que ultrapassa */
   text-overflow: ellipsis;  

--- a/src/reports/templates/InventarioEspecies.tsx
+++ b/src/reports/templates/InventarioEspecies.tsx
@@ -20,16 +20,16 @@ function InventarioEspecies({ dados }: InventarioEspeciesProps) {
   return (
     <Page title="Relatório de Inventário de Espécies">
       {dados.map((grupo) => (
-        <div key={grupo.familia} id="grupoComBorda">
-          <div id="nomeGrupoContainer">
-            <h1 id="nomeGrupo"><b>Família: </b>{grupo.familia}</h1>
-          </div>
+        <div key={grupo.familia} className="grupoComBorda">
 
           <table>
             <thead>
-              <tr id="tabelaComBordaSimples">
-                <th id="col1">Espécie</th>
-                <th id="col2">Tombos relacionados</th>
+              <tr className="nomeGrupoContainer">
+                <th className="nomeGrupo" colSpan={2}><b>Família: </b>{grupo.familia}</th>
+              </tr>
+              <tr className="tabelaComBordaSimples">
+                <th className="col1">Espécie</th>
+                <th className="col2">Tombos relacionados</th>
               </tr>
             </thead>
             <tbody>

--- a/src/reports/templates/LocaisColeta.tsx
+++ b/src/reports/templates/LocaisColeta.tsx
@@ -97,7 +97,7 @@ function RelacaoLocaisColeta({ dados, total, textoFiltro }: RelacaoLocaisColetaP
   const renderItem = (item: LocaisColeta) => {
     return (
       <div>
-        <div key={item.local} id="grupoLocalColeta">
+        <div key={item.local} className="grupoLocalColeta">
           <div>
             <h1>UF.: {item.estadoSigla}</h1>
           </div>

--- a/src/routes/locais.js
+++ b/src/routes/locais.js
@@ -1,9 +1,10 @@
+import listagensMiddleware from '~/middlewares/listagens-middleware';
+
 import tokensMiddleware, { TIPOS_USUARIOS } from '../middlewares/tokens-middleware';
 import validacoesMiddleware from '../middlewares/validacoes-middleware';
 import localColetaCadastroEsquema from '../validators/localColeta-cadastro';
 import localColetaListagemEsquema from '../validators/localColeta-listagem';
 import nomeEsquema from '../validators/nome-obrigatorio';
-import listagensMiddleware from '~/middlewares/listagens-middleware';
 
 const controller = require('../controllers/locais-coleta-controller');
 

--- a/src/validators/tombo-data-tombo.js
+++ b/src/validators/tombo-data-tombo.js
@@ -1,4 +1,4 @@
-export default (data) => {
+export default data => {
     if (typeof data !== 'string') {
         return false;
     }
@@ -15,6 +15,5 @@ export default (data) => {
     if (mes < 1 || mes > 12) return false;
     if (dia < 1 || dia > 31) return false;
 
-
     return true;
-}
+};


### PR DESCRIPTION
## Fix/85 adiciona familia no topo da pagina de relatorio

Closes #85 <br/>

## O que foi feito
Foi alterada a estilização dos relatórios que utilizam IDs em loops para o formato de classes. Ainda, foi inserido o que antes era o nome da família ao início do grupo, no início de cada página quando o mesmo grupo continua.

## Teste realizados
Verificação se o nome da família persiste ao quebrar página
<img width="1904" height="1207" alt="Screenshot 2025-09-17 at 18 53 23" src="https://github.com/user-attachments/assets/7990cd3d-f737-4c30-8fce-44b8e9d634ab" />
