### PR TITLE
Retirar obrigatoriedade de Herbário e Localidade

### DIFF
--- a/src/validators/tombo-cadastro.js
+++ b/src/validators/tombo-cadastro.js
@@ -14,7 +14,9 @@ export default {
     },
     'json.principal.entidade_id': {
         in: 'body',
-        isEmpty: false,
+        optional: {
+            options: { nullable: true },
+        },
         isInt: true,
     },
     'json.principal.numero_coleta': {

--- a/src/validators/tombo-cor.js
+++ b/src/validators/tombo-cor.js
@@ -1,1 +1,1 @@
-export default cor => cor === 'VERMELHO' || cor === 'AZUL' || cor === 'VERDE';
+export default cor => cor === 'VERMELHO' || cor === 'AZUL' || cor === 'VERDE' || cor === '';


### PR DESCRIPTION
- Permitir entidade_id no cadastro do tombo ser null.
- Permitir cor vazia na validação de cor.