### PR TITLE
Fix/211 alteração na validação de erros do CRUD estados e cidades

### DIFF
--- a/src/controllers/cidades-controller.js
+++ b/src/controllers/cidades-controller.js
@@ -12,24 +12,33 @@ const { Cidade, LocalColeta, Tombo, Reino, Familia, Subfamilia, Genero, Especie,
 export const cadastrarCidade = (req, res, next) => {
     const { nome, estado_id: estadoId, latitude, longitude } = req.body;
 
-    const callback = transaction => Promise.resolve()
-        .then(() => Cidade.findOne({
-            where: {
-                nome,
-                estado_id: estadoId,
-            },
+    const callback = async (transaction) => {
+        const cidadeEncontrada = await Cidade.findOne({
+            where: { nome, estado_id: estadoId },
             transaction,
-        }))
-        .then(cidadeEncontrada => {
-            if (cidadeEncontrada) {
-                throw new BadRequestException(402); // Cidade já existe
-            }
-        })
-        .then(() => Cidade.create({ nome, estado_id: estadoId, latitude, longitude }, { transaction }));
+        });
 
-    return sequelize.transaction(callback)
-        .then(cidadeCriada => {
-            if (!cidadeCriada) throw new BadRequestException(403);
+        if (cidadeEncontrada) {
+            return res.status(400).json({
+                error: {
+                    code: 308,
+                    mensagem: `Já existe uma cidade com esse nome cadastrada neste estado.`
+                }
+            });
+        }
+
+        const cidadeCriada = await Cidade.create(
+            { nome, estado_id: estadoId, latitude, longitude },
+            { transaction }
+        );
+
+        return cidadeCriada;
+    };
+
+    return sequelize
+        .transaction(callback)
+        .then((cidadeCriada) => {
+            if (!cidadeCriada) throw new BadRequestException(403, "Erro ao cadastrar a cidade.");
             return res.status(codigos.CADASTRO_RETORNO).json(cidadeCriada);
         })
         .catch(next);
@@ -39,18 +48,42 @@ export const atualizarCidade = async (req, res, next) => {
     try {
         const { cidadeId } = req.params;
         const dados = pick(req.body, ['nome', 'estado_id', 'latitude', 'longitude']);
-
-        const [updated] = await Cidade.update(dados, { where: { id: cidadeId } });
-        if (updated === 0) {
-            return res.status(404).json({ mensagem: 'Cidade não encontrada.' });
+        const cidadeAtual = await Cidade.findOne({ where: { id: cidadeId } });
+        if (!cidadeAtual) {
+            return res.status(404).json({
+                error: {
+                    code: 404,
+                    mensagem: 'Cidade não encontrada.'
+                }
+            });
         }
+        const cidadeConflitante = await Cidade.findOne({
+            where: {
+                nome: dados.nome,
+                estado_id: dados.estado_id ?? cidadeAtual.estado_id,
+                id: { [Op.ne]: cidadeId }
+            }
+        });
+        if (cidadeConflitante) {
+            return res.status(400).json({
+                error: {
+                    code: 308,
+                    mensagem: `Já existe uma cidade com esse nome cadastrada neste estado.`
+                }
+            });
+        }
+        await Cidade.update(dados, { where: { id: cidadeId } });
+        const cidadeAtualizada = await Cidade.findOne({
+            where: { id: cidadeId },
+            attributes: ['id', 'nome', 'estado_id', 'latitude', 'longitude']
+        });
 
-        const cidadeAtualizada = await Cidade.findOne({ where: { id: cidadeId } });
         return res.status(codigos.EDITAR_RETORNO).json(cidadeAtualizada);
     } catch (error) {
         return next(error);
     }
 };
+
 
 export const desativarCidade = async (req, res, next) => {
     try {
@@ -65,7 +98,10 @@ export const desativarCidade = async (req, res, next) => {
 
         if (locaisAssociados > 0) {
             return res.status(400).json({
-                mensagem: `Não é possível excluir a cidade. Existem ${locaisAssociados} local(is) de coleta associado(s) a esta cidade.`,
+                error: {
+                    code: 400,
+                    mensagem: `Não é possível excluir a cidade. Existem ${locaisAssociados} local(is) de coleta associado(s) a esta cidade.`,
+                }
             });
         }
 
@@ -94,12 +130,19 @@ export const encontrarCidade = async (req, res, next) => {
     }
 };
 
-export const listaTodosCidades = where =>
+export const listaTodosCidades = (where) =>
     Cidade.findAndCountAll({
         attributes: {
             exclude: ['updated_at', 'created_at'],
         },
         where,
+        include: [
+            {
+                model: models.Estado,
+                as: 'estado',
+                attributes: ['id', 'nome', 'sigla', 'codigo_telefone', 'pais_id'],
+            },
+        ],
     });
 
 export const listagem = (request, response, next) => {
@@ -110,9 +153,10 @@ export const listagem = (request, response, next) => {
             estado_id: request.query.id,
         };
     }
+
     Promise.resolve()
         .then(() => listaTodosCidades(where))
-        .then(cidades => {
+        .then((cidades) => {
             response.status(200).json(cidades.rows);
         })
         .catch(next);

--- a/src/controllers/cidades-controller.js
+++ b/src/controllers/cidades-controller.js
@@ -12,7 +12,7 @@ const { Cidade, LocalColeta, Tombo, Reino, Familia, Subfamilia, Genero, Especie,
 export const cadastrarCidade = (req, res, next) => {
     const { nome, estado_id: estadoId, latitude, longitude } = req.body;
 
-    const callback = async (transaction) => {
+    const callback = async transaction => {
         const cidadeEncontrada = await Cidade.findOne({
             where: { nome, estado_id: estadoId },
             transaction,
@@ -22,8 +22,8 @@ export const cadastrarCidade = (req, res, next) => {
             return res.status(400).json({
                 error: {
                     code: 308,
-                    mensagem: `Já existe uma cidade com esse nome cadastrada neste estado.`
-                }
+                    mensagem: 'Já existe uma cidade com esse nome cadastrada neste estado.',
+                },
             });
         }
 
@@ -37,8 +37,8 @@ export const cadastrarCidade = (req, res, next) => {
 
     return sequelize
         .transaction(callback)
-        .then((cidadeCriada) => {
-            if (!cidadeCriada) throw new BadRequestException(403, "Erro ao cadastrar a cidade.");
+        .then(cidadeCriada => {
+            if (!cidadeCriada) throw new BadRequestException(403, 'Erro ao cadastrar a cidade.');
             return res.status(codigos.CADASTRO_RETORNO).json(cidadeCriada);
         })
         .catch(next);
@@ -53,29 +53,29 @@ export const atualizarCidade = async (req, res, next) => {
             return res.status(404).json({
                 error: {
                     code: 404,
-                    mensagem: 'Cidade não encontrada.'
-                }
+                    mensagem: 'Cidade não encontrada.',
+                },
             });
         }
         const cidadeConflitante = await Cidade.findOne({
             where: {
                 nome: dados.nome,
                 estado_id: dados.estado_id ?? cidadeAtual.estado_id,
-                id: { [Op.ne]: cidadeId }
-            }
+                id: { [Op.ne]: cidadeId },
+            },
         });
         if (cidadeConflitante) {
             return res.status(400).json({
                 error: {
                     code: 308,
-                    mensagem: `Já existe uma cidade com esse nome cadastrada neste estado.`
-                }
+                    mensagem: 'Já existe uma cidade com esse nome cadastrada neste estado.',
+                },
             });
         }
         await Cidade.update(dados, { where: { id: cidadeId } });
         const cidadeAtualizada = await Cidade.findOne({
             where: { id: cidadeId },
-            attributes: ['id', 'nome', 'estado_id', 'latitude', 'longitude']
+            attributes: ['id', 'nome', 'estado_id', 'latitude', 'longitude'],
         });
 
         return res.status(codigos.EDITAR_RETORNO).json(cidadeAtualizada);
@@ -83,7 +83,6 @@ export const atualizarCidade = async (req, res, next) => {
         return next(error);
     }
 };
-
 
 export const desativarCidade = async (req, res, next) => {
     try {
@@ -101,7 +100,7 @@ export const desativarCidade = async (req, res, next) => {
                 error: {
                     code: 400,
                     mensagem: `Não é possível excluir a cidade. Existem ${locaisAssociados} local(is) de coleta associado(s) a esta cidade.`,
-                }
+                },
             });
         }
 
@@ -130,7 +129,7 @@ export const encontrarCidade = async (req, res, next) => {
     }
 };
 
-export const listaTodosCidades = (where) =>
+export const listaTodosCidades = where =>
     Cidade.findAndCountAll({
         attributes: {
             exclude: ['updated_at', 'created_at'],
@@ -156,7 +155,7 @@ export const listagem = (request, response, next) => {
 
     Promise.resolve()
         .then(() => listaTodosCidades(where))
-        .then((cidades) => {
+        .then(cidades => {
             response.status(200).json(cidades.rows);
         })
         .catch(next);

--- a/src/controllers/estados-controller.js
+++ b/src/controllers/estados-controller.js
@@ -1,4 +1,5 @@
 import pick from '~/helpers/pick';
+
 import BadRequestException from '../errors/bad-request-exception';
 import models from '../models';
 import codigos from '../resources/codigos-http';
@@ -14,15 +15,15 @@ const {
 export const cadastrarEstado = (req, res, next) => {
     const { nome, sigla, codigo_telefone: codigoTelefone, pais_id: paisId } = req.body;
 
-    const callback = async (transaction) => {
+    const callback = async transaction => {
         const estadoConflitante = await Estado.findOne({
             where: {
                 pais_id: paisId,
                 [Sequelize.Op.or]: [
                     { nome },
                     { sigla },
-                    { codigo_telefone: codigoTelefone }
-                ]
+                    { codigo_telefone: codigoTelefone },
+                ],
             },
             transaction,
         });
@@ -36,12 +37,11 @@ export const cadastrarEstado = (req, res, next) => {
             return res.status(400).json({
                 error: {
                     code: 308,
-                    mensagem: `Já existe um estado com este ${campoDuplicado} neste país.`
-                }
+                    mensagem: `Já existe um estado com este ${campoDuplicado} neste país.`,
+                },
             });
 
         }
-
 
         const estadoCriado = await Estado.create(
             { nome, sigla, codigo_telefone: codigoTelefone, pais_id: paisId },
@@ -52,12 +52,12 @@ export const cadastrarEstado = (req, res, next) => {
     };
 
     return sequelize.transaction(callback)
-        .then(async (estadoCriado) => {
+        .then(async estadoCriado => {
             if (!estadoCriado) throw new BadRequestException(309);
             const estadoComPais = await Estado.findOne({
                 where: { id: estadoCriado.id },
                 attributes: { exclude: ['created_at', 'updated_at'] },
-                include: [{ model: Pais, as: 'pais', attributes: ['id', 'nome', 'sigla'] }]
+                include: [{ model: Pais, as: 'pais', attributes: ['id', 'nome', 'sigla'] }],
             });
 
             return res.status(codigos.CADASTRO_RETORNO).json(estadoComPais);
@@ -112,9 +112,9 @@ export const atualizarEstado = async (req, res, next) => {
                 [Sequelize.Op.or]: [
                     { nome: dados.nome },
                     { sigla: dados.sigla },
-                    { codigo_telefone: dados.codigo_telefone }
-                ]
-            }
+                    { codigo_telefone: dados.codigo_telefone },
+                ],
+            },
         });
 
         if (estadoConflitante) {
@@ -126,8 +126,8 @@ export const atualizarEstado = async (req, res, next) => {
             return res.status(400).json({
                 error: {
                     code: 308,
-                    mensagem: `Já existe um estado com este ${campoDuplicado} neste país.`
-                }
+                    mensagem: `Já existe um estado com este ${campoDuplicado} neste país.`,
+                },
             });
         }
 
@@ -137,7 +137,7 @@ export const atualizarEstado = async (req, res, next) => {
         const estadoAtualizado = await Estado.findOne({
             where: { id: estadoId },
             attributes: ['id', 'nome', 'sigla', 'codigo_telefone', 'pais_id'],
-            include: [{ model: Pais, as: 'pais', attributes: ['id', 'nome', 'sigla'] }]
+            include: [{ model: Pais, as: 'pais', attributes: ['id', 'nome', 'sigla'] }],
         });
 
         return res.status(codigos.EDITAR_RETORNO).json(estadoAtualizado);
@@ -159,10 +159,10 @@ export const desativarEstado = async (req, res, next) => {
 
         if (cidadesAssociadas > 0) {
             return res.status(400).json({
-                error:{
+                error: {
                     code: 400,
                     mensagem: `Não é possível excluir o estado. Existem ${cidadesAssociadas} cidade(s) associada(s) a este estado.`,
-                }
+                },
             });
         }
 


### PR DESCRIPTION
Exemplo de retorno PUT cidade com um nome já existente:
<img width="1493" height="476" alt="image" src="https://github.com/user-attachments/assets/c8ea4734-0d8f-4fee-89a4-0319f7b55a67" />

Exemplo de retorno POST estado já existente:
<img width="1502" height="884" alt="image" src="https://github.com/user-attachments/assets/4a1bffcf-a214-4ad4-8004-f72b806e9049" />
