### PR TITLE
Adiciona migração para atualizar a latitude do tombo 43011

### DIFF
--- a/src/database/migration/20250924233712_fix-tombo-43011.ts
+++ b/src/database/migration/20250924233712_fix-tombo-43011.ts
@@ -1,0 +1,9 @@
+import { Knex } from 'knex'
+
+export async function run(knex: Knex): Promise<void> {
+  await knex.transaction(async trx => {
+    await trx('tombos')
+      .where({ hcf: 43011 })
+      .update({ latitude: -24.528 })
+  })
+}


### PR DESCRIPTION
- Corrigir valor da latitude do tombo 43011 que impede que abra a tela de edição e visualização desse tombo.