### PR TITLE
Fix/231 reestrutura ficha tombo

### DIFF
--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -14,6 +14,7 @@ const {
     Coletor,
     Familia,
     Especie,
+    Subfamilia,
 
     Subespecie,
     Variedade,
@@ -96,6 +97,9 @@ export default function fichaTomboController(request, response, next) {
                         model: Autor,
                         as: 'autor',
                     },
+                },
+                {
+                    model: Subfamilia,
                 },
                 {
                     model: Variedade,
@@ -214,8 +218,21 @@ export default function fichaTomboController(request, response, next) {
                     return { ...resultado, fotos };
                 });
         })
-        .then(resultado => {
+        .then(async resultado => {
             const { tombo, identificacao, fotos } = resultado;
+
+            // await Subfamilia.findAll({
+            //     where: {
+            //         familia_id: dadosTombo.familia?.id,
+            //     },
+            //     include: [
+            //         {
+            //             model: Autor,
+            //             attributes: ['id', 'nome'],
+            //             as: 'autor',
+            //         },
+            //     ],
+            // });
 
             // eslint-disable-next-line max-len
             const coletores = `${!!tombo?.coletore?.nome !== false ? tombo?.coletore?.nome?.concat(' ') : ''}${tombo?.coletor_complementar ? tombo.coletor_complementar?.complementares : ''}`;
@@ -261,6 +278,7 @@ export default function fichaTomboController(request, response, next) {
                 especie: tombo.especie,
                 variedade: tombo.variedade,
                 subespecie: tombo.sub_especy,
+                subfamilia: tombo.sub_familia,
 
                 relevo: tombo?.relevo?.nome || '',
                 vegetacao: tombo?.vegetaco?.nome || '',
@@ -293,6 +311,8 @@ export default function fichaTomboController(request, response, next) {
                 numero_copias: qtd || 1,
                 codigo_barras_selecionado: code,
             };
+
+            // console.log(parametros);
 
             const caminhoArquivoHtml = path.resolve(__dirname, '../views/ficha-tombo.ejs');
             return renderizaArquivoHtml(caminhoArquivoHtml, parametros, response)

--- a/src/controllers/fichas-tombos-controller.js
+++ b/src/controllers/fichas-tombos-controller.js
@@ -312,8 +312,6 @@ export default function fichaTomboController(request, response, next) {
                 codigo_barras_selecionado: code,
             };
 
-            // console.log(parametros);
-
             const caminhoArquivoHtml = path.resolve(__dirname, '../views/ficha-tombo.ejs');
             return renderizaArquivoHtml(caminhoArquivoHtml, parametros, response)
                 .then(html => {

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -40,7 +40,7 @@
         border-collapse: collapse;
         border: 1px solid #000;
         width: 14cm;
-        min-height: 9cm;
+        min-height: 7cm;
         margin-bottom: 5px;
       }
 
@@ -112,6 +112,10 @@
         margin-left: 0.25rem;
       }
 
+      .ml-2 {
+        margin-left: 0.5rem;
+      }
+
       .limited-div-50 {
         max-width: 7cm;
       }
@@ -172,10 +176,10 @@
                     <%- especie.autore.nome %>
                 <% } %>
                 <% if (variedade && variedade.nome) { %>
-                    var. <i><%- variedade.nome %></i>
+                  <text class="ml-2">var. </text><i><%- variedade.nome %></i>
                 <% } %>
-                <% if (variedade && variedade.autore) { %>
-                    <%- variedade.autore.nome %>
+                <% if (variedade && variedade.autor) { %>
+                    <%- variedade.autor.nome %>
                 <% } %>
                 <% if (subespecie && subespecie.nome) { %>
                     subsp. <i><%- subespecie.nome %></i>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -115,6 +115,10 @@
       .limited-div-50 {
         max-width: 7cm;
       }
+
+      .limited-code-div {
+        min-width: 5cm;
+      }
     </style>
     <body>
       <% if ( imprimir === '0') { %>
@@ -251,7 +255,7 @@
                   </div>
                 </div>
 
-                <div class="flex flex-col gap-1">
+                <div class="flex flex-col gap-1 limited-code-div">
                   <div class="flex center-between w-full">
                     <div>
                       <b class="fs-14">nº:</b> <%- tombo.numero_coleta %>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -1,111 +1,160 @@
-<!DOCTYPE html>
-<html lang="pt-BR">
+<%# Nesse arquivo, há a criação da ficha tombo, que é exibida quando se %>
+<%# deseja imprimir dados de um tombo específico, por exemplo. %>
 
-<head>
+<!DOCTYPE html>
+<html lang="pt-br">
+  <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Ficha Tombo</title>
     <style>
-        @page {
-          margin: 0;
-        }
+      @page {
+        margin: 0;
+      }
 
-        html,
-        body {
-          font-size: 12px;
-          font-family: Arial, Helvetica, sans-serif;
-          padding-top: 8px;
-          padding-left: 8px;
-        }
+      html, body {
+        font-size: 12px;
+        font-family: Arial, Helvetica, sans-serif;
+        padding-top: 8px;
+        padding-left: 8px;
+      }
 
-        body {
-          max-width: 80%;
-        }
+      body {
+        max-width: 80%;
+      }
 
-        .break-line-before {
-          page-break-before: always;
-          page-break-inside: avoid;
-        }
+      .pad-padrao {
+        padding: 2px 8px;
+      }
 
-        .text-center {
-          text-align: center;
-        }
+      .pad-topbottom {
+        padding: 20px 8px;
+      }
 
-        .text-right {
-          text-align: right;
-        }
+      .w-full {
+        width: 100%;
+      }
 
-        .tabela-principal {
-          border-collapse: collapse;
-          border: 1px solid #333;
-          width: 14cm;
-          min-height: 9cm;
-          margin-bottom: 5px;
-        }
+      .ficha {
+        border-collapse: collapse;
+        border: 1px solid #000;
+        width: 14cm;
+        min-height: 9cm;
+        margin-bottom: 5px;
+      }
 
-        .tabela-principal td {
-          padding: 2px 8px;
-        }
+      .flex {
+        display: flex;
+      }
 
-        .tabela-principal tr:first-child > td:first-child {
-          border-right: 1px solid #333;
-        }
+      .border-right {
+        border-right: 1px solid #000;
+      }
 
-        .tabela-principal .linha-vazia {
-          height: 5px;
-        }
+      .border-bottom {
+        border-bottom: 1px solid #000;
+      }
 
-        .tabela-principal .celular-imagem {
-          border-right: 1px solid #333;
-          border-bottom: 1px solid #333;
-        }
+      .cabecalho-img {
+        width: 100px;
+      }
 
-        .border-bottom {
-          border-bottom: 1px solid #333;
-        }
-      </style>
-</head>
+      .cabecalho-info {
+        flex: 1;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: space-between;
+      }
 
-<body>
-    <% if ( imprimir === '0') { %>
+      .center-between {
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .fs-14 {
+        font-size: 14px;
+      }
+
+      .flex-col {
+        flex-direction: column;
+      }
+
+      .gap-1 {
+        gap: 0.25rem;
+      }
+
+      .linha-vazia {
+        height: 5px;
+      }
+
+      .items-center {
+        align-items: center;
+      }
+
+      .items-start {
+        align-items: flex-start;
+      }
+
+      .start-between {
+        align-items: flex-start;
+        justify-content: space-between;
+      }
+
+      .center-end {
+        align-items: center;
+        justify-content: flex-end;
+      }
+
+      .ml-1 {
+        margin-left: 0.25rem;
+      }
+
+      .limited-div-50 {
+        max-width: 7cm;
+      }
+    </style>
+    <body>
+      <% if ( imprimir === '0') { %>
         <% fotos.length = 1%>
-    <% } %>
-    <% const copias = parseInt(numero_copias || 1); %>
-    <% let fichaIndex = 0; %>
-    <% for (let i = 0; i < fotos.length; i++) { 
-      for (let j = 0; j < copias; j++) { %>
-    <% if (fichaIndex !== 0 && fichaIndex % 3 === 0) { %>
-      
-    <% } %>
-    <table class="tabela-principal">
-        <tr>
-            <td rowspan="2" width="100" class="celular-imagem text-center">
+      <% } %>
+
+      <% const copias = parseInt(numero_copias || 1); %>
+      <% let fichaIndex = 0; %>
+
+      <% for (let i = 0; i < fotos.length; i++) { %>
+        <% for (let j = 0; j < copias; j++) { %>
+          <div class="ficha">
+            <!-- Cabeçalho da ficha -->
+            <div class="flex">
+              <div class="cabecalho-img pad-padrao border-right border-bottom">
                 <img width="100" src="/assets/logotipo_HCF.png" alt="Logo UTFPR">
-                <div style="font-size: .5em;"><b>CAMPUS CAMPO MOURÃO</b></div>
-            </td>
-            <td colspan="3" class="text-center">
-                <b style="font-size: 14px;">Herbário da Universidade Tecnológica Federal do Paraná - <br/>Campus Campo Mourão</b>
-            </td>
-        </tr>
-        <tr class="border-bottom">
-            <td colspan="2" style="border: none;">
-                <b style="font-size: 14px;">HCF <%- tombo.hcf %></b>
-            </td>
-            <td colspan="2" style="font-size: 14px;">
-                <div style="display: flex;"><b>Data:</b> <%- romano_data_tombo %></div>
-            </td>
-        </tr>
-        <% if (familia && familia.nome) { %>
-        <tr>
-            <td colspan="4">
-                <b style="font-size: 14px;">Família: </b> <%- tombo.familia.nome %>
-            </td>
-        </tr>
-        <% } %>
-        <tr>
-            <td colspan="4">
-                <b style="font-size: 14px;">Espécie:</b>
+              </div>
+              <div class="cabecalho-info pad-topbottom border-bottom">
+                <b class="fs-14">Herbário da Universidade Tecnológica Federal do Paraná - <br/>Campus Campo Mourão</b>
+              
+                <div class="flex center-between w-full">
+                  <b class="fs-14">HCF <%- tombo.hcf %></b>
+
+                  <div class="flex fs-14">
+                    <b>Data:</b> <%- romano_data_tombo %>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Corpo da ficha -->
+             <div class="flex flex-col pad-padrao gap-1">
+              <% if (familia && familia.nome) { %>
+                <div>
+                  <b class="fs-14">Família: </b> <%- tombo.familia.nome %>
+                </div>
+              <% } %>
+
+              <div>
+                <b class="fs-14">Espécie:</b>
                 <% if (genero && genero.nome) { %>
                     <i><%- genero.nome %></i>
                 <% } %>
@@ -122,32 +171,28 @@
                     <%- variedade.autore.nome %>
                 <% } %>
                 <% if (subespecie && subespecie.nome) { %>
-                    ssp. <i><%- subespecie.nome %></i>
+                    subsp. <i><%- subespecie.nome %></i>
                 <% } %>
                 <% if (subespecie && subespecie.autore) { %>
                     <%- subespecie.autore.nome %>
                 <% } %>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="4" class="linha-vazia"></td>
-        </tr>
-        <tr>
-            <td colspan="4">
-                <b style="font-size: 14px;">Nome Vulgar:</b> <%- tombo.nomes_populares %>
-            </td>
-        </tr>
-        <tr>
-          <td colspan="3">
-              <b style="font-size: 14px;">Identificador:</b> <%- identificador %>
-          </td>
-          <td>
-            <b style="font-size: 14px;">Data:</b> <%- romano_data_identificacao %>
-          </td>
-        </tr>
-        <tr>
-            <td colspan="4">
-                <b style="font-size: 14px;">Local de coleta:</b>
+              </div>
+
+              <div class="linha-vazia"></div>
+
+              <div>
+                <b class="fs-14">Nome Vulgar:</b> <%- tombo.nomes_populares %>
+              </div>
+              <div class="flex center-between">
+                <div>
+                  <b class="fs-14">Identificador:</b> <%- identificador %>
+                </div>
+                <div>
+                  <b class="fs-14">Data:</b> <%- romano_data_identificacao %>
+                </div>
+              </div>
+              <div>
+                <b class="fs-14">Local de Coleta:</b>
                 <% if (localColeta && localColeta.complemento) { %>
                     <%- localColeta.complemento %>
                 <% } %>
@@ -163,14 +208,12 @@
                 <% if (cidade && cidade.estado && cidade.estado.pais) { %>
                     - <%- cidade.estado.pais.nome %>
                 <% } %>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="4" class="linha-vazia"></td>
-        </tr>
-        <tr>
-            <td colspan="4">
-                <b style="font-size: 14px;">Observações:</b> 
+              </div>
+
+              <div class="linha-vazia"></div>
+
+              <div>
+                <b class="fs-14">Observações:</b>
                 <% if (tombo && tombo.descricao) { %>
                     <%- tombo.descricao %>
                 <% } %>
@@ -195,60 +238,57 @@
                 <% if (localColeta && localColeta.fase_sucessional) { %>
                     - Fase sucessional: <%- localColeta.fase_sucessional.nome %>
                 <% } %>
-            </td>
-        </tr>
-        <tr>
-            <td colspan="4" class="linha-vazia"></td>
-        </tr>
-        <tr>
-            <td colspan="4" class="linha-vazia"></td>
-        </tr>
-        <tr>
-            <td colspan="2">
-              <div style="display: flex; gap: 5px;">
-                <b style="font-size: 14px;"><%- tombo.coletores.length == 1 ? 'Coletor' : 'Coletores' %>:</b>
+              </div>
+
+              <div class="linha-vazia"></div>
+              <div class="linha-vazia"></div>
+
+              <div class="flex start-between">
+                <div class="flex items-start">
+                  <b class="fs-14"><%- tombo.coletores.length == 1 ? 'Coletor' : 'Coletores' %>:</b>
+                  <div class="ml-1 limited-div-50">
+                    <%- tombo.coletores %>
+                  </div>
+                </div>
+
                 <div>
-                  <%- tombo.coletores %>
+                  <b class="fs-14">nº:</b> <%- tombo.numero_coleta %>
+                </div>
+
+                <div>
+                  <b class="fs-14">Data:</b> <%- romano_data_coleta %>
                 </div>
               </div>
-            </td>
-            <td width="19%" class="text-right" style="text-align:right; vertical-align:top;">
-                <b>nº:</b> <%- tombo.numero_coleta %>
-            </td>
-            <td width="21%" class="text-right" style="text-align:right; vertical-align:top;">
-                <b>Data:</b> <%- romano_data_coleta %>
-            </td>
-        </tr>
-        <% if (!!fotos[i]['id'] && imprimir !== '0') { %>
-        <tr>
-            <td colspan="4" class="text-right">
-                <svg id="<%- 'code128_' + fotos[i]['id'] %>"></svg>
-            </td>
-        </tr>
+
+              <% if (!!fotos[i]['id'] && imprimir !== '0') { %>
+                <div class="flex center-end">
+                  <svg id="<%- 'code128_' + fotos[i]['id'] %>"></svg>
+                </div>
+              <% } %>
+             </div>
+          </div>
+          <% if (!!fotos[i]['id'] && imprimir !== '0') { %>
+            <script>
+              window.addEventListener('load', () => {
+                const id = "<%- '#code128_' + fotos[i]['id'] %>";
+                const cbarra = "<%- codigo_barras_selecionado %>";
+                JsBarcode(id, cbarra, { margin: 0, width: 1.4, height: 40, fontSize: 10 });
+              });
+            </script>
+          <% } %>
+          <% fichaIndex++; %>
         <% } %>
-    </table>
-    <% if (!!fotos[i]['id'] && imprimir !== '0') { %>
-    <script>
-        window.addEventListener('load', () => {
-            const id = "<%- '#code128_' + fotos[i]['id'] %>";
-            const cbarra = "<%- codigo_barras_selecionado %>";
-            JsBarcode(id, cbarra, { margin: 0, width: 1.4, height: 40, fontSize: 10 });
-        });
-    </script>
-    <% } %>
-    <% fichaIndex++; %>
-    <% } %>
-    <% } %>
-    <script src="/assets/js/jsbarcode.code128.min.js"></script>
-    <script>
+      <% } %>
+      <script src="/assets/js/jsbarcode.code128.min.js"></script>
+      <script>
         function onPageLoaded() {
-            if (!/standalone/.test(window.location.href)) {
-                window.print();
-            }
+          if (!/standalone/.test(window.location.href)) {
+            window.print();
+          }
         }
 
         window.addEventListener('load', onPageLoaded);
-    </script>
-</body>
-
+      </script>
+    </body>
+  </head>
 </html>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -251,20 +251,26 @@
                   </div>
                 </div>
 
-                <div>
-                  <b class="fs-14">nº:</b> <%- tombo.numero_coleta %>
-                </div>
+                <div class="flex flex-col gap-1">
+                  <div class="flex center-between w-full">
+                    <div>
+                      <b class="fs-14">nº:</b> <%- tombo.numero_coleta %>
+                    </div>
+    
+                    <div>
+                      <b class="fs-14">Data:</b> <%- romano_data_coleta %>
+                    </div>
+                  </div>
 
-                <div>
-                  <b class="fs-14">Data:</b> <%- romano_data_coleta %>
+                  <div class="linha-vazia"></div>
+
+                  <% if (!!fotos[i]['id'] && imprimir !== '0') { %>
+                    <div class="flex center-end">
+                      <svg id="<%- 'code128_' + fotos[i]['id'] %>"></svg>
+                    </div>
+                  <% } %>
                 </div>
               </div>
-
-              <% if (!!fotos[i]['id'] && imprimir !== '0') { %>
-                <div class="flex center-end">
-                  <svg id="<%- 'code128_' + fotos[i]['id'] %>"></svg>
-                </div>
-              <% } %>
              </div>
           </div>
           <% if (!!fotos[i]['id'] && imprimir !== '0') { %>

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -172,8 +172,8 @@
                 <% if (especie && especie.nome) { %>
                     <i><%- especie.nome %></i>
                 <% } %>
-                <% if (especie && especie.autore) { %>
-                    <%- especie.autore.nome %>
+                <% if (especie && especie.autor) { %>
+                    <%- especie.autor.nome %>
                 <% } %>
                 <% if (variedade && variedade.nome) { %>
                   <text class="ml-2">var. </text><i><%- variedade.nome %></i>
@@ -182,10 +182,10 @@
                     <%- variedade.autor.nome %>
                 <% } %>
                 <% if (subespecie && subespecie.nome) { %>
-                    subsp. <i><%- subespecie.nome %></i>
+                  <text class="ml-2">subsp. </text><i><%- subespecie.nome %></i>
                 <% } %>
-                <% if (subespecie && subespecie.autore) { %>
-                    <%- subespecie.autore.nome %>
+                <% if (subespecie && subespecie.autor) { %>
+                    <%- subespecie.autor.nome %>
                 <% } %>
               </div>
 

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -154,6 +154,9 @@
               <% if (familia && familia.nome) { %>
                 <div>
                   <b class="fs-14">Família: </b> <%- tombo.familia.nome %>
+                  <% if (tombo && tombo.sub_familia) { %>
+                    - <%- subfamilia.nome %>
+                <% } %>
                 </div>
               <% } %>
 


### PR DESCRIPTION
Closes #231 

## O que foi feito
Foi feita uma reestruturação da Ficha Tombo, mudando o tamanho de alguns atributos e adicionando/corrigindo/retirando campos passados pelo professor @andreschwerz durante as conversas em grupo e reunião semanal.

## Exemplo de fichas com a refatoração
<img width="550" height="371" alt="Screenshot 2025-09-29 at 00 53 52" src="https://github.com/user-attachments/assets/cc14c8ae-fb4f-4c3f-9756-315a50eb0ede" />
<img width="545" height="371" alt="Screenshot 2025-09-29 at 00 54 02" src="https://github.com/user-attachments/assets/2a256aec-2ccb-4263-921c-5a99f744fcfb" />
<img width="548" height="371" alt="Screenshot 2025-09-29 at 00 54 10" src="https://github.com/user-attachments/assets/cc509c35-470f-4e1a-a90f-ba89ffafe70d" />
<img width="546" height="397" alt="Screenshot 2025-09-29 at 00 54 18" src="https://github.com/user-attachments/assets/3aba6a51-3520-4d99-9842-04453a66535a" />
