### PR TITLE
Correção atualização da espécie

### DIFF
--- a/src/controllers/taxonomias-controller.js
+++ b/src/controllers/taxonomias-controller.js
@@ -649,6 +649,7 @@ export const cadastrarEspecie = (request, response, next) => {
             where: {
                 nome,
                 genero_id: generoId,
+                ativo: true,
             },
             transaction,
         }))

--- a/src/validators/especie-atualiza.js
+++ b/src/validators/especie-atualiza.js
@@ -12,11 +12,6 @@ export default {
         isInt: true,
         isEmpty: false,
     },
-    familia_id: {
-        in: 'body',
-        isInt: true,
-        isEmpty: false,
-    },
     autor_id: {
         in: 'body',
         isInt: true,


### PR DESCRIPTION
- Retirado parâmetros desnecessários do middleware de validação da atualização da espécie.
- Ao cadastrar uma espécie, valida duplicação usando apenas registros marcados como ativo.