### PR TITLE
Correção do Nome Científico

### DIFF
--- a/src/controllers/pendencias-controller.js
+++ b/src/controllers/pendencias-controller.js
@@ -1235,7 +1235,6 @@ export const aprovarPendencia = async (alteracao, hcf, transaction) => {
             if (!familia) {
                 throw new BadRequestExeption(404);
             }
-            nomesCientificosPartes.push(familia.nome);
         }
 
         updateTombo.familia_id = alteracao.familia_id;
@@ -1264,7 +1263,6 @@ export const aprovarPendencia = async (alteracao, hcf, transaction) => {
             if (!subfamilia) {
                 throw new BadRequestExeption(404);
             }
-            nomesCientificosPartes.push(subfamilia.nome);
         }
 
         updateTombo.sub_familia_id = alteracao.sub_familia_id;
@@ -1345,7 +1343,6 @@ export const aprovarPendencia = async (alteracao, hcf, transaction) => {
             if (!subespecie) {
                 throw new BadRequestExeption(404);
             }
-            nomesCientificosPartes.push(subespecie.nome);
         }
 
         updateTombo.sub_especie_id = alteracao.sub_especie_id;
@@ -1370,7 +1367,6 @@ export const aprovarPendencia = async (alteracao, hcf, transaction) => {
             if (!variedade) {
                 throw new BadRequestExeption(404);
             }
-            nomesCientificosPartes.push(variedade.nome);
         }
 
         updateTombo.variedade_id = alteracao.variedade_id;
@@ -1378,7 +1374,7 @@ export const aprovarPendencia = async (alteracao, hcf, transaction) => {
 
     if (nomesCientificosPartes.length > 0) {
         updateTombo.nome_cientifico = nomesCientificosPartes.join(' ');
-    } else if (Object.keys(updateTombo).some(key => key.includes('familia_id') || key.includes('genero_id') || key.includes('especie_id') || key.includes('sub_especie_id') || key.includes('variedade_id'))) {
+    } else if (Object.keys(updateTombo).some(key => key.includes('genero_id') || key.includes('especie_id'))) {
         updateTombo.nome_cientifico = null;
     }
 

--- a/src/controllers/tombos-controller.js
+++ b/src/controllers/tombos-controller.js
@@ -173,7 +173,6 @@ export const cadastro = (request, response, next) => {
                     if (!familia) {
                         throw new BadRequestExeption(402);
                     }
-                    taxonomia.nome_cientifico = familia.nome;
                 }
                 return undefined;
             })
@@ -194,7 +193,6 @@ export const cadastro = (request, response, next) => {
                     if (!subfamilia) {
                         throw new BadRequestExeption(403);
                     }
-                    taxonomia.nome_cientifico += ` ${subfamilia.nome}`;
                 }
                 return undefined;
             })
@@ -215,7 +213,7 @@ export const cadastro = (request, response, next) => {
                     if (!genero) {
                         throw new BadRequestExeption(404);
                     }
-                    taxonomia.nome_cientifico += ` ${genero.nome}`;
+                    taxonomia.nome_cientifico = genero.nome;
                 }
                 return undefined;
             })
@@ -257,7 +255,6 @@ export const cadastro = (request, response, next) => {
                     if (!subespecie) {
                         throw new BadRequestExeption(406);
                     }
-                    taxonomia.nome_cientifico += ` ${subespecie.nome}`;
                 }
                 return undefined;
             })
@@ -278,7 +275,6 @@ export const cadastro = (request, response, next) => {
                     if (!variedade) {
                         throw new BadRequestExeption(407);
                     }
-                    taxonomia.nome_cientifico += ` ${variedade.nome}`;
                 }
                 return undefined;
             })

--- a/src/database/migration/20251001194607_fix-nome-cientifico.ts
+++ b/src/database/migration/20251001194607_fix-nome-cientifico.ts
@@ -1,0 +1,41 @@
+import { Knex } from 'knex'
+
+export async function run(knex: Knex): Promise<void> {
+  await knex.transaction(async (trx) => {
+    const tombos = await trx('tombos')
+      .select('hcf', 'genero_id', 'especie_id')
+      .where('hcf', '>=', 42852)
+
+    for (const tombo of tombos) {
+      let nomeCientifico = null
+
+      if (tombo.genero_id) {
+        const genero = await trx('generos')
+          .select('nome')
+          .where('id', tombo.genero_id)
+          .first()
+
+        if (genero) {
+          nomeCientifico = genero.nome
+
+          if (tombo.especie_id) {
+            const especie = await trx('especies')
+              .select('nome')
+              .where('id', tombo.especie_id)
+              .first()
+
+            if (especie) {
+              nomeCientifico = `${genero.nome} ${especie.nome}`
+            }
+          }
+        }
+      }
+
+      await trx('tombos')
+        .where('hcf', tombo.hcf)
+        .update({
+          nome_cientifico: nomeCientifico
+        })
+    }
+  })
+}

--- a/src/database/migration/20251001194607_fix-nome-cientifico.ts
+++ b/src/database/migration/20251001194607_fix-nome-cientifico.ts
@@ -6,7 +6,7 @@ export async function run(knex: Knex): Promise<void> {
       .select('hcf', 'genero_id', 'especie_id')
       .where('hcf', '>=', 42852)
 
-    for (const tombo of tombos) {
+    const updates = tombos.map(async (tombo) => {
       let nomeCientifico = null
 
       if (tombo.genero_id) {
@@ -31,11 +31,13 @@ export async function run(knex: Knex): Promise<void> {
         }
       }
 
-      await trx('tombos')
+      return trx('tombos')
         .where('hcf', tombo.hcf)
         .update({
           nome_cientifico: nomeCientifico
         })
-    }
+    })
+
+    await Promise.all(updates)
   })
 }


### PR DESCRIPTION
- Correção do problema que ao cadastrar ou editar um tombo, ele mudava o valor do nome científico considerando todos os níveis de taxonomia, e não apenas o gênero e espécie.
- Adiciona migration para corrigir dados incorretos.