### PR TITLE
fix: Resolve problema com os códigos de barra da ficha tombo

### DIFF
--- a/public/js/ficha-tombo.js
+++ b/public/js/ficha-tombo.js
@@ -1,0 +1,18 @@
+window.addEventListener('load', () => {
+  const svg = document.querySelector('[id^="code128_"]');
+  if (!svg) return;
+
+  if (typeof JsBarcode !== 'function') {
+    console.error('JsBarcode não carregado. Verifique o caminho do script e a CSP.');
+    return;
+  }
+  const attr = svg.getAttribute('data-codigo-barras');
+  const id = svg.id;
+  const cbarra = attr || '';
+  JsBarcode('#'.concat(id), cbarra, { margin: 0, width: 1.4, height: 40, fontSize: 10 });
+
+
+  if (!/standalone/.test(window.location.href)) {
+    window.print();
+  }
+});

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -239,14 +239,14 @@
               <% if (tombo && tombo.altitude) { %>
                   - Altitude: <%- tombo.altitude %>m
               <% } %>
-              <% if (localColeta && localColeta.solo) { %>
-                  - Solo: <%- localColeta.solo.nome %>
+              <% if (tombo.solo) { %>
+                  - Solo: <%- tombo.solo.nome %>
               <% } %>
-              <% if (localColeta && localColeta.relevo) { %>
-                  - Relevo: <%- localColeta.relevo.nome %>
+              <% if (tombo.relevo) { %>
+                  - Relevo: <%- tombo.relevo.nome %>
               <% } %>
-              <% if (localColeta && localColeta.vegetaco) { %>
-                  - Vegetação: <%- localColeta.vegetaco.nome %>
+              <% if (tombo.vegetacao) { %>
+                  - Vegetação: <%- tombo.vegetacao.nome %>
               <% } %>
               <% if (localColeta && localColeta.fase_sucessional) { %>
                   - Fase sucessional: <%- localColeta.fase_sucessional.nome %>
@@ -278,34 +278,17 @@
 
                 <% if (!!fotos[0]['id'] && imprimir !== '0') { %>
                   <div class="flex center-end">
-                    <svg id="<%- 'code128_' + fotos[0]['id'] %>"></svg>
+                    <svg id="<%- 'code128_' + fotos[0]['id'] %>" data-codigo-barras="<%- codigo_barras_selecionado %>"></svg>
                   </div>
                 <% } %>
               </div>
             </div>
             </div>
         </div>
-        <% if (!!fotos[0]['id'] && imprimir !== '0') { %>
-          <script>
-            window.addEventListener('load', () => {
-              const id = "<%- '#code128_' + fotos[0]['id'] %>";
-              const cbarra = "<%- codigo_barras_selecionado %>";
-              JsBarcode(id, cbarra, { margin: 0, width: 1.4, height: 40, fontSize: 10 });
-            });
-          </script>
-        <% } %>
         <% fichaIndex++; %>
       <% } %>
       <script src="/assets/js/jsbarcode.code128.min.js"></script>
-      <script>
-        function onPageLoaded() {
-          if (!/standalone/.test(window.location.href)) {
-            window.print();
-          }
-        }
-
-        window.addEventListener('load', onPageLoaded);
-      </script>
+      <script src="/assets/js/ficha-tombo.js"></script>
     </body>
   </head>
 </html>


### PR DESCRIPTION
Closes #267 

## O que foi feito
Scripts do tipo _inline_ foram retirados e trocados por script externo colocado na pas `/public/js/`. O funcionamento ainda é o mesmo, no entanto, a função para utilização do `JSBarcCode` foi refatorada, de modo a ficar mais legível e possibilitar manutenção mais rápida futuramente, em caso de necessidade. <br/>

Para a exibição dos parâmetros `solo`, `relevo` e `vegetacao` foi tracada verificações relacionadas para obtenção de dentro do objeto `tombo`.

## Ficha tombo após alterações
<img width="549" height="349" alt="Screenshot 2025-10-23 at 19 58 14" src="https://github.com/user-attachments/assets/d11c5faa-0c34-4f56-995d-13b2b58459a1" />
