### PR TITLE
Altera ordem solo, relevo, vegetacao

### DIFF
--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -230,15 +230,6 @@
               <% if (tombo && tombo.descricao) { %>
                   <%- tombo.descricao %>
               <% } %>
-              <% if (tombo && tombo.latitude) { %>
-                  - Latitude: <%- tombo.latitude %>
-              <% } %>
-              <% if (tombo && tombo.longitude) { %>
-                  - Longitude: <%- tombo.longitude %>
-              <% } %>
-              <% if (tombo && tombo.altitude) { %>
-                  - Altitude: <%- tombo.altitude %>m
-              <% } %>
               <% if (tombo.solo) { %>
                   - Solo: <%- tombo.solo.nome %>
               <% } %>
@@ -247,6 +238,15 @@
               <% } %>
               <% if (tombo.vegetacao) { %>
                   - Vegetação: <%- tombo.vegetacao.nome %>
+              <% } %>
+              <% if (tombo && tombo.latitude) { %>
+                  - Latitude: <%- tombo.latitude %>
+              <% } %>
+              <% if (tombo && tombo.longitude) { %>
+                  - Longitude: <%- tombo.longitude %>
+              <% } %>
+              <% if (tombo && tombo.altitude) { %>
+                  - Altitude: <%- tombo.altitude %>m
               <% } %>
               <% if (localColeta && localColeta.fase_sucessional) { %>
                   - Fase sucessional: <%- localColeta.fase_sucessional.nome %>


### PR DESCRIPTION
## O que foi feito
Somente foram colocadas as informações sobre `solo`, `relevo` e `vegetação` para depois da `observação` e antes dos demais