### PR TITLE
Adiciona referência a cidade na tabela de tombos

### DIFF
--- a/src/controllers/darwincore-controller.js
+++ b/src/controllers/darwincore-controller.js
@@ -103,24 +103,24 @@ const obterModeloDarwinCoreLotes = async (limit, offset, request, response) => {
                 model: TomboFoto,
             },
             {
-                model: LocalColeta,
+                model: Cidade,
+                attributes: {
+                    exclude: ['updated_at', 'created_at'],
+                },
                 include: [
                     {
-                        model: Cidade,
-                        attributes: {
-                            exclude: ['updated_at', 'created_at'],
-                        },
+                        model: Estado,
                         include: [
                             {
-                                model: Estado,
-                                include: [
-                                    {
-                                        model: Pais,
-                                    },
-                                ],
+                                model: Pais,
                             },
                         ],
                     },
+                ],
+            },
+            {
+                model: LocalColeta,
+                include: [
                     {
                         model: FaseSucessional,
                         attributes: {
@@ -206,13 +206,10 @@ const obterModeloDarwinCoreLotes = async (limit, offset, request, response) => {
         let dataIdentificacao = '';
         let identificationQualifier = '';
         let nomeIdentificador = '';
-        const paisNome
-            = tombo.locais_coletum && tombo.locais_coletum.cidade ? tombo.locais_coletum.cidade.estado.paise.nome : '';
-        const paisCodigo
-            = tombo.locais_coletum && tombo.locais_coletum.cidade ? tombo.locais_coletum.cidade.estado.paise.sigla : '';
-        const paranaNome
-            = tombo.locais_coletum && tombo.locais_coletum.cidade ? tombo.locais_coletum.cidade.estado.nome : '';
-        const cidadeNome = tombo.locais_coletum && tombo.locais_coletum.cidade ? tombo.locais_coletum.cidade.nome : '';
+        const paisNome = tombo?.cidade?.estado?.paise?.nome ?? '';
+        const paisCodigo = tombo?.cidade?.estado?.paise?.sigla ?? '';
+        const paranaNome = tombo?.cidade?.estado?.nome ?? '';
+        const cidadeNome = tombo?.cidade?.nome ?? '';
         const vegetacao
             = tombo.locais_coletum && tombo.locais_coletum.vegetacao ? tombo.locais_coletum.vegetacao.nome : '';
         const familiaNome = tombo.familia ? tombo.familia.nome : '';

--- a/src/controllers/pendencias-controller.js
+++ b/src/controllers/pendencias-controller.js
@@ -1365,8 +1365,34 @@ export const aprovarPendencia = async (alteracao, hcf, transaction) => {
             if (!localColeta) {
                 throw new BadRequestExeption(404);
             }
+
+            const cidadeRefId = (alteracao.cidade_id !== undefined)
+                ? alteracao.cidade_id
+                : tomboAtual.cidade_id;
+
+            if (cidadeRefId !== undefined && cidadeRefId !== null) {
+                if (localColeta.cidade_id !== cidadeRefId) {
+                    throw new BadRequestExeption(535);
+                }
+            }
         }
         updateTombo.local_coleta_id = alteracao.local_coleta_id;
+    }
+
+    if (alteracao.cidade_id !== undefined) {
+        if (alteracao.cidade_id !== null) {
+            const cidade = await Cidade.findOne({
+                where: { id: alteracao.cidade_id },
+                transaction,
+                raw: true,
+                nest: true,
+            });
+
+            if (!cidade) {
+                throw new BadRequestExeption(404);
+            }
+        }
+        updateTombo.cidade_id = alteracao.cidade_id;
     }
 
     if (alteracao.descricao !== undefined) {

--- a/src/controllers/tombos-controller.js
+++ b/src/controllers/tombos-controller.js
@@ -121,8 +121,23 @@ export const cadastro = (request, response, next) => {
                 return undefined;
             })
             .then(() => {
+                if (!localidade?.cidade_id) {
+                    throw new BadRequestExeption(534);
+                }
+                return Cidade.findOne({
+                    where: { id: localidade.cidade_id },
+                    transaction,
+                });
+            })
+            .then(cidade => {
+                if (!cidade) {
+                    throw new BadRequestExeption(534);
+                }
+                return undefined;
+            })
+            .then(() => {
                 if (!localidade?.local_coleta_id) {
-                    throw new BadRequestExeption(400);
+                    return undefined;
                 }
                 return LocalColeta.findOne({
                     where: {
@@ -132,8 +147,13 @@ export const cadastro = (request, response, next) => {
                 });
             })
             .then(localColeta => {
-                if (!localColeta) {
-                    throw new BadRequestExeption(533);
+                if (localidade?.local_coleta_id) {
+                    if (!localColeta) {
+                        throw new BadRequestExeption(533);
+                    }
+                    if (localColeta.cidade_id !== localidade.cidade_id) {
+                        throw new BadRequestExeption(535);
+                    }
                 }
                 return undefined;
             })
@@ -283,13 +303,17 @@ export const cadastro = (request, response, next) => {
                     data_coleta_mes: principal.data_coleta.mes,
                     data_coleta_ano: principal.data_coleta.ano,
                     numero_coleta: principal.numero_coleta,
-                    local_coleta_id: localidade.local_coleta_id,
+                    cidade_id: localidade.cidade_id,
                     coletor_id: coletor,
                     data_tombo: parseDataTombo(principal.data_tombo),
                 };
 
                 if (paisagem?.descricao) {
                     jsonTombo.descricao = paisagem.descricao;
+                }
+
+                if (localidade.local_coleta_id) {
+                    jsonTombo.local_coleta_id = localidade.local_coleta_id;
                 }
 
                 if (observacoes) {
@@ -518,6 +542,9 @@ function alteracaoCuradorouOperador(request, response, transaction) {
 
     const altitude = body?.localidade?.altitude;
     if (altitude !== undefined) update.altitude = altitude;
+
+    const cidadeId = body?.localidade?.cidade_id;
+    if (cidadeId !== undefined) update.cidade_id = cidadeId;
 
     const localColeta = body?.localidade?.local_coleta_id;
     if (localColeta !== undefined) update.local_coleta_id = localColeta;
@@ -1009,21 +1036,21 @@ export const obterTombo = async (request, response, next) => {
                             },
                         },
                         {
-                            model: LocalColeta,
+                            model: Cidade,
                             include: [
                                 {
-                                    model: Cidade,
+                                    model: Estado,
                                     include: [
                                         {
-                                            model: Estado,
-                                            include: [
-                                                {
-                                                    model: Pais,
-                                                },
-                                            ],
+                                            model: Pais,
                                         },
                                     ],
                                 },
+                            ],
+                        },
+                        {
+                            model: LocalColeta,
+                            include: [
                                 {
                                     model: FaseSucessional,
                                     attributes: {
@@ -1100,9 +1127,9 @@ export const obterTombo = async (request, response, next) => {
                 resposta = {
                     herbarioInicial: tombo.herbario !== null ? tombo.herbario?.id : '',
                     tipoInicial: tombo.tipo !== null ? tombo.tipo?.id : '',
-                    paisInicial: tombo.locais_coletum.cidade?.estado?.paise !== null ? tombo.locais_coletum.cidade?.estado?.paise?.id : '',
-                    estadoInicial: tombo.locais_coletum.cidade?.estado !== null ? tombo.locais_coletum.cidade?.estado?.id : '',
-                    cidadeInicial: tombo.locais_coletum.cidade !== null ? tombo.locais_coletum?.cidade?.id : '',
+                    paisInicial: tombo.cidade?.estado?.paise?.id ?? '',
+                    estadoInicial: tombo.cidade?.estado?.id ?? '',
+                    cidadeInicial: tombo.cidade !== null ? tombo.cidade?.id : tombo.cidade_id ?? '',
                     reinoInicial: tombo.reino !== null ? tombo.reino?.id : '',
                     familiaInicial: tombo.familia !== null ? tombo.familia?.id : '',
                     subfamiliaInicial: tombo.sub_familia !== null ? tombo.sub_familia?.id : '',
@@ -1146,10 +1173,10 @@ export const obterTombo = async (request, response, next) => {
                         long_min: tombo.longitude !== null ? converteDecimalParaGMSMinutos(tombo.longitude, false) : '',
                         long_sec: tombo.longitude !== null ? converteDecimalParaGMSSegundos(tombo.longitude, false) : '',
                         altitude: tombo.altitude !== null ? tombo.altitude : '',
-                        cidade: tombo.locais_coletum !== null && tombo.locais_coletum.cidade !== null ? tombo.locais_coletum?.cidade?.nome : '',
-                        estado: tombo.locais_coletum !== null && tombo.locais_coletum.cidade !== null ? tombo.locais_coletum.cidade?.estado?.nome : '',
-                        pais: tombo.locais_coletum !== null && tombo.locais_coletum.cidade !== null ? tombo.locais_coletum.cidade.estado?.paise?.nome : '',
-                        complemento: tombo.locais_coletum?.complemento !== null ? tombo.locais_coletum?.complemento : '',
+                        cidade: tombo.cidade?.nome ?? '',
+                        estado: tombo.cidade?.estado?.nome ?? '',
+                        pais: tombo.cidade?.estado?.paise?.nome ?? '',
+                        complemento: tombo.complemento !== null ? tombo.complemento : '',
                     },
                     local_coleta: {
                         id: tombo.locais_coletum !== null ? tombo.locais_coletum?.id : '',
@@ -1236,7 +1263,7 @@ export const obterTombo = async (request, response, next) => {
             .then(() =>
                 Estado.findAll({
                     where: {
-                        pais_id: dadosTombo.locais_coletum.cidade?.estado?.paise?.id,
+                        pais_id: dadosTombo.cidade.estado?.paise?.id,
                     },
                 }),
             )
@@ -1245,7 +1272,7 @@ export const obterTombo = async (request, response, next) => {
             .then(() =>
                 Cidade.findAll({
                     where: {
-                        estado_id: dadosTombo.locais_coletum.cidade?.estado?.id,
+                        estado_id: dadosTombo.cidade.estado?.id,
                     },
                 }),
             )

--- a/src/database/migration/20251110180244_cidade_tombo.ts
+++ b/src/database/migration/20251110180244_cidade_tombo.ts
@@ -1,0 +1,30 @@
+import { Knex } from 'knex'
+
+export async function run(knex: Knex): Promise<void> {
+  await knex.transaction(async trx => {
+    const hasCol = await trx.schema.hasColumn('tombos', 'cidade_id')
+    if (!hasCol) {
+      await trx.schema.alterTable('tombos', table => {
+        table.integer('cidade_id').unsigned().nullable().index()
+      })
+    } else {
+      await trx.raw('ALTER TABLE `tombos` MODIFY `cidade_id` INT UNSIGNED NULL')
+    }
+
+    await trx.schema.alterTable('tombos', table => {
+      table
+        .foreign('cidade_id', 'fk_tombos_cidade')
+        .references('cidades.id')
+        .onUpdate('CASCADE')
+        .onDelete('SET NULL')
+    })
+
+    await trx.raw(`
+      UPDATE tombos t
+      JOIN locais_coleta lc ON lc.id = t.local_coleta_id
+      SET t.cidade_id = lc.cidade_id
+      WHERE t.local_coleta_id IS NOT NULL
+        AND (t.cidade_id IS NULL OR t.cidade_id = 0)
+    `)
+  })
+}

--- a/src/models/Tombo.js
+++ b/src/models/Tombo.js
@@ -24,6 +24,7 @@ function associate(modelos) {
         TomboFoto,
         TomboIdentificador,
         Identificador,
+        Cidade,
     } = modelos;
 
     Tombo.hasMany(TomboFoto, {
@@ -129,6 +130,10 @@ function associate(modelos) {
 
     Tombo.belongsTo(ColecaoAnexa, {
         foreignKey: 'colecao_anexa_id',
+    });
+
+    Tombo.belongsTo(Cidade, {
+        foreignKey: 'cidade_id',
     });
 }
 
@@ -263,6 +268,10 @@ export default (Sequelize, DataTypes) => {
         },
         unicata: {
             type: DataTypes.BOOLEAN,
+            allowNull: true,
+        },
+        cidade_id: {
+            type: DataTypes.INTEGER,
             allowNull: true,
         },
     };

--- a/src/validators/tombo-cadastro.js
+++ b/src/validators/tombo-cadastro.js
@@ -95,7 +95,7 @@ export default {
     'json.localidade.local_coleta_id': {
         in: 'body',
         isInt: true,
-        isEmpty: false,
+        optional: true,
     },
     'json.paisagem.solo_id': {
         in: 'body',


### PR DESCRIPTION
- Adiciona nova coluna na tabela de tombo para referenciar a tabela cidade.
- Adequa cadastro / edição para refletir a nova coluna.
- Validação para sempre o local de coleta ser da cidade informada.
- Migration para atribuir valores em cidade_id do tombo com base no cidade_id do local de coleta associado a ele.