### PR TITLE
feat/Script atualizar latitude e longitude da cidade

### DIFF
--- a/src/utils/scripts/update_coordinates.ts
+++ b/src/utils/scripts/update_coordinates.ts
@@ -1,0 +1,52 @@
+import dotenv from 'dotenv'
+import path from 'path'
+import { Client } from 'pg'
+import { fileURLToPath } from 'url'
+
+const currentFilename = fileURLToPath(import.meta.url)
+const currentDirname = path.dirname(currentFilename)
+const projectRoot = path.resolve(currentDirname, '..', '..', '..')
+
+dotenv.config({ path: path.join(projectRoot, '.env') })
+
+const {
+  PG_DATABASE,
+  PG_USERNAME,
+  PG_PASSWORD,
+  PG_HOST,
+  PG_PORT,
+  DATABASE_URL
+} = process.env
+
+const connectionString
+  = DATABASE_URL
+    || `postgresql://${PG_USERNAME}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DATABASE}`
+
+function isValidConnectionString(cs: string | undefined): boolean {
+  return typeof cs === 'string' && cs.length > 0 && !/undefined/.test(cs)
+}
+
+if (!isValidConnectionString(connectionString)) {
+  process.exit(1)
+}
+
+async function main(): Promise<void> {
+  const client = new Client({ connectionString })
+  await client.connect()
+
+  try {
+    await client.query(`
+      UPDATE cidades
+      SET 
+        latitude = ST_Y(ST_PointOnSurface(poligono)),
+        longitude = ST_X(ST_PointOnSurface(poligono)),
+        updated_at = NOW()
+      WHERE poligono IS NOT NULL
+        AND (latitude IS NULL OR longitude IS NULL);
+    `)
+  } finally {
+    await client.end()
+  }
+}
+
+main().catch(() => process.exit(1))


### PR DESCRIPTION
- Busca todas as cidades que possuem polígono mas não possuem latitude ou longitude

- Calcula as coordenadas usando ST_PointOnSurface(poligono), que retorna um ponto garantidamente dentro do polígono

- Atualiza os campos latitude e longitude da tabela cidades

- Atualiza o campo updated_at com a data atual