### PR TITLE
fix: corrigir edição de tombo (PUT /api/tombos/:id) falhando com Post…

### DIFF
--- a/src/controllers/pendencias-controller.js
+++ b/src/controllers/pendencias-controller.js
@@ -1370,7 +1370,7 @@ export const aprovarPendencia = async (alteracao, hcf, transaction) => {
                 : tomboAtual.cidade_id;
 
             if (cidadeRefId !== undefined && cidadeRefId !== null) {
-                if (localColeta.cidade_id !== cidadeRefId) {
+                if (Number(localColeta.cidade_id) !== Number(cidadeRefId)) {
                     throw new BadRequestExeption(535);
                 }
             }
@@ -1573,7 +1573,7 @@ export const aprovarPendencia = async (alteracao, hcf, transaction) => {
     }
 
     const tomboFinal = await Tombo.findOne({
-        where: { hcf, ativo: 1 },
+        where: { hcf, ativo: true },
         transaction,
         raw: true,
         nest: true,

--- a/src/controllers/tombos-controller.js
+++ b/src/controllers/tombos-controller.js
@@ -397,7 +397,7 @@ export const cadastro = (request, response, next) => {
                     usuario_id: request.usuario.id,
                     status,
                     tombo_json: JSON.stringify(tomboData),
-                    ativo: true,
+                    ativo: 1,
                     identificacao: 1,
                 };
                 tomboCriado = tombo;
@@ -486,7 +486,7 @@ function alteracaoIdentificador(request, transaction) {
             usuario_id: request.usuario.id,
             status: 'ESPERANDO',
             tombo_json: JSON.stringify(update),
-            ativo: true,
+            ativo: 1,
             identificacao: 1,
         }, { transaction }))
         .then(alteracaoIdent => {
@@ -612,7 +612,7 @@ function alteracaoCuradorouOperador(request, response, transaction) {
         usuario_id: request.usuario.id,
         status: 'ESPERANDO',
         tombo_json: JSON.stringify(update),
-        ativo: true,
+        ativo: 1,
         identificacao: 1,
     }, { transaction })
         .then(alteracaoCriada => {

--- a/src/middlewares/tokens-middleware.js
+++ b/src/middlewares/tokens-middleware.js
@@ -21,8 +21,9 @@ export default (tipoUsuarioPermitido = []) =>
             }
 
             const usuario = decodificaTokenUsuario(token);
+            usuario.tipo_usuario_id = Number(usuario.tipo_usuario_id);
 
-            const estaPermitido = !Array.isArray(tipoUsuarioPermitido) || tipoUsuarioPermitido.length < 1 || tipoUsuarioPermitido.includes(Number(usuario.tipo_usuario_id));
+            const estaPermitido = !Array.isArray(tipoUsuarioPermitido) || tipoUsuarioPermitido.length < 1 || tipoUsuarioPermitido.includes(usuario.tipo_usuario_id);
 
             if (!estaPermitido) {
                 throw new ForbiddenException(102);

--- a/src/models/Alteracao.js
+++ b/src/models/Alteracao.js
@@ -41,11 +41,11 @@ export default (Sequelize, DataTypes) => {
             allowNull: false,
         },
         ativo: {
-            type: DataTypes.BOOLEAN,
+            type: DataTypes.SMALLINT,
             allowNull: true,
         },
         identificacao: {
-            type: DataTypes.BOOLEAN,
+            type: DataTypes.SMALLINT,
             allowNull: true,
         },
     };


### PR DESCRIPTION
…greSQL

- Normalizar tipo_usuario_id para Number no tokens-middleware após decodificar JWT, corrigindo comparações === no controller
- Alterar tipo de ativo/identificacao de BOOLEAN para SMALLINT no modelo Alteracao para corresponder à coluna smallint do PostgreSQL
- Corrigir valores ativo: true → ativo: 1 nos Alteracao.create() do tombos-controller
- Usar Number() na comparação cidade_id no pendencias-controller para evitar mismatch de tipos string vs integer
- Corrigir query Tombo.findOne para usar ativo: true (boolean) ao invés de ativo: 1 (integer) no pendencias-controller