### PR TITLE
Fix/ Complemento Local de Coleta

### DIFF
--- a/src/controllers/locais-coleta-controller.js
+++ b/src/controllers/locais-coleta-controller.js
@@ -208,7 +208,7 @@ export const buscarFasesSucessionais = (request, response, next) => {
 
 export const cadastrarLocalColeta = async (request, response, next) => {
     try {
-        const dados = pick(request.body, ['descricao', 'complemento', 'cidade_id', 'fase_sucessional_id']);
+        const dados = pick(request.body, ['descricao', 'cidade_id', 'fase_sucessional_id']);
         const localColeta = await LocalColeta.create(dados);
         response.status(201).json(localColeta);
     } catch (error) {
@@ -321,7 +321,7 @@ export const buscarLocalColetaPorId = async (request, response, next) => {
 export const atualizarLocalColeta = async (request, response, next) => {
     try {
         const { id } = request.params;
-        const dados = pick(request.body, ['descricao', 'complemento', 'cidade_id', 'fase_sucessional_id']);
+        const dados = pick(request.body, ['descricao', 'cidade_id', 'fase_sucessional_id']);
         const [updated] = await LocalColeta.update(dados, {
             where: { id },
         });

--- a/src/controllers/relatorios-controller.js
+++ b/src/controllers/relatorios-controller.js
@@ -213,7 +213,7 @@ export const obtemDadosDoRelatorioDeColetaPorLocalEIntervaloDeData = async (req,
                 },
                 {
                     model: LocalColeta,
-                    attributes: ['id', 'descricao', 'complemento'],
+                    attributes: ['id', 'descricao'],
                     where: whereLocal,
                     required: true,
                 },
@@ -578,7 +578,7 @@ export const obtemDadosDoRelatorioDeLocalDeColeta = async (req, res, next) => {
                 },
                 {
                     model: LocalColeta,
-                    attributes: ['id', 'descricao', 'complemento'],
+                    attributes: ['id', 'descricao'],
                     where: whereLocal,
                     required: true,
                     include: {

--- a/src/helpers/formata-dados-relatorio.js
+++ b/src/helpers/formata-dados-relatorio.js
@@ -58,9 +58,7 @@ const defineNomeCientifico = dado => {
 export const formatarDadosParaRelatorioDeColetaPorLocalEIntervaloDeData = dados => {
     const romanos = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX', 'X', 'XI', 'XII'];
     const dadosFormatados = dados.map(dado => ({
-        local: dado.locais_coletum?.complemento
-            ? `${dado.locais_coletum.descricao} ${dado.locais_coletum.complemento}`
-            : dado.locais_coletum?.descricao,
+        local: dado.locais_coletum?.descricao,
         data: `${String(dado.data_coleta_dia).padStart(2, '0')}/${romanos[dado.data_coleta_mes - 1]}/${dado.data_coleta_ano}`,
         tombo: dado?.hcf,
         numeroColeta: dado.numero_coleta || '-',

--- a/src/models/LocalColeta.js
+++ b/src/models/LocalColeta.js
@@ -35,10 +35,7 @@ export default (Sequelize, DataTypes) => {
             type: DataTypes.TEXT,
             allowNull: true,
         },
-        complemento: {
-            type: DataTypes.TEXT,
-            allowNull: true,
-        },
+
         cidade_id: {
             type: DataTypes.INTEGER,
             allowNull: true,

--- a/src/validators/localColeta-cadastro.js
+++ b/src/validators/localColeta-cadastro.js
@@ -5,11 +5,7 @@ export default {
         notEmpty: true,
         errorMessage: 'Descrição é obrigatória.',
     },
-    complemento: {
-        in: ['body'],
-        isString: true,
-        optional: true,
-    },
+
     cidade_id: {
         in: ['body'],
         isInt: true,

--- a/src/views/ficha-tombo.ejs
+++ b/src/views/ficha-tombo.ejs
@@ -213,9 +213,7 @@
             </div>
             <div>
               <b class="fs-14">Local de Coleta:</b>
-              <% if (localColeta && localColeta.complemento) { %>
-                  <%- localColeta.complemento %>
-              <% } %>
+
               <% if (localColeta && localColeta.descricao) { %>
                   <%- localColeta.descricao %>
               <% } %>


### PR DESCRIPTION
Após tirar a coluna de complemento da tabela de locais_coleta foi necessário ajustar as logicas para não mais considerar o complemento

- Model (LocalColeta.js): Removido atributo complemento
- Controller (locais-coleta-controller.js): Removido complemento do pick() nas funções de criação e atualização
- Controller (relatorios-controller.js): Removido complemento dos attributes de LocalColeta em 2 consultas de relatórios
- Helper (formata-dados-relatorio.js): Simplificado campo local para usar somente descricao
- Validator (localColeta-cadastro.js): Removida regra de validação do complemento
- View (ficha-tombo.ejs): Removido bloco de exibição do complemento