### PR TITLE
Migration para atualizar nome_cientifico dos tombos que estao inconsi…

### DIFF
--- a/src/database/migration/20260404170000_fix-nome-cientifico-inconsistente.ts
+++ b/src/database/migration/20260404170000_fix-nome-cientifico-inconsistente.ts
@@ -1,0 +1,28 @@
+import { Knex } from 'knex'
+
+export async function run(knex: Knex): Promise<void> {
+  await knex.transaction(async trx => {
+    // Atualiza tombos que possuem genero e especie
+    await trx.raw(`
+      UPDATE tombos
+      SET nome_cientifico = CONCAT(g.nome, ' ', e.nome)
+      FROM generos g, especies e
+      WHERE tombos.genero_id = g.id
+        AND tombos.especie_id = e.id
+        AND (
+          tombos.nome_cientifico IS DISTINCT FROM CONCAT(g.nome, ' ', e.nome)
+          OR e.genero_id IS DISTINCT FROM tombos.genero_id
+        )
+    `)
+
+    // Atualiza tombos que possuem apenas genero (sem especie)
+    await trx.raw(`
+      UPDATE tombos
+      SET nome_cientifico = g.nome
+      FROM generos g
+      WHERE tombos.genero_id = g.id
+        AND tombos.especie_id IS NULL
+        AND tombos.nome_cientifico IS DISTINCT FROM g.nome
+    `)
+  })
+}


### PR DESCRIPTION
…stentes com a concatenação do genero.nome e especie.nome ou apenas genero.nome quando o especie_id do tombo esta vazio