### PR TITLE
477 notificar falha backup

### DIFF
--- a/script/database-backup/.env.example
+++ b/script/database-backup/.env.example
@@ -1,8 +1,8 @@
-DATABASE_HOST=10.0.10.80
+DATABASE_HOST=127.0.0.1
 DATABASE_PORT=5432
 DATABASE_USER=postgres
 DATABASE_PASSWORD=masterkey
-DATABASE_NAME=herbario_prod
+DATABASE_NAME=herbario_dev
 
 # Google Drive (Dados reais que você gerou)
 GDRIVE_TOKEN={"access_token":"SEU_ACCESS_TOKEN_AQUI","token_type":"Bearer","refresh_token":"SEU_REFRESH_TOKEN_AQUI","expiry":"2026-01-01T00:00:00Z"}
@@ -14,3 +14,15 @@ RETENTION_DAILY=5
 RETENTION_WEEKLY=4
 CRON_SCHEDULE="0 2 * * *"
 TZ=America/Sao_Paulo
+
+# SMTP (notificação de falha do backup)
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER="seu-email@gmail.com"
+SMTP_PASS="sua-senha-de-app-de-16-digitos"
+SMTP_FROM="Sistema HCF <no-reply@hcf.com>"
+
+# Destinatários do alerta (1 ou mais, separados por vírgula)
+NOTIFY_EMAIL_TO=ops@exemplo.com,curadoria@exemplo.com
+# Desliga notificação sem remover config (default: true)
+NOTIFY_EMAIL_ENABLED=true

--- a/script/database-backup/Dockerfile
+++ b/script/database-backup/Dockerfile
@@ -9,7 +9,8 @@ RUN \
     curl \
     ca-certificates \
     rclone \
-    gzip && \
+    gzip \
+    msmtp && \
   curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql.gpg && \
   echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
   apt-get update && \
@@ -17,7 +18,6 @@ RUN \
     postgresql-client-18 && \
   apt-get remove -y \
     curl \
-    ca-certificates \
     gnupg && \
   rm -rf /var/lib/apt/lists/*
 

--- a/script/database-backup/README.md
+++ b/script/database-backup/README.md
@@ -10,7 +10,7 @@ Arquitetura:
 
 Fluxo:
 
-`cron -> backup.sh -> pg_dump -Fp -> gzip -> rclone copy -> retenção`
+`cron -> backup.sh -> pg_dump -Fp -> gzip -> rclone copy -> retenção (-> notificação por e-mail em caso de falha)`
 
 ## Formato do backup
 
@@ -37,6 +37,23 @@ Veja `.env.example` para o contrato completo.
 - `RETENTION_WEEKLY` (default: `4`)
 - `CRON_SCHEDULE` (ex.: `0 2 * * *`)
 - `TZ` (ex.: `America/Sao_Paulo`)
+- `SMTP_HOST`
+- `SMTP_PORT`
+- `SMTP_USER`
+- `SMTP_PASS`
+- `SMTP_FROM`
+- `NOTIFY_EMAIL_TO` (1 ou mais e-mails separados por vírgula)
+- `NOTIFY_EMAIL_ENABLED` (default: `true`)
+
+## Notificação de falha
+
+O container instala e configura o cliente `msmtp` (via `/etc/msmtprc`, gerado no `entrypoint.sh` a partir das variáveis `SMTP_*`).
+
+- O `backup.sh` captura toda a sua saída em um log temporário e usa um `trap ERR` para detectar qualquer falha (`pg_dump`, `rclone`, retenção, etc.).
+- Em caso de falha, um e-mail é enviado via `msmtp` para todos os endereços listados em `NOTIFY_EMAIL_TO` (separados por vírgula), com assunto, horário (`TZ`) e as últimas linhas do log.
+- Em caso de sucesso, nenhum e-mail é enviado.
+- `NOTIFY_EMAIL_ENABLED=false` desliga a notificação sem precisar remover as demais variáveis.
+- Se o próprio envio do e-mail falhar (SMTP fora do ar, credenciais inválidas etc.), isso é apenas logado — o script continua terminando com o código de saída original da falha do backup (a notificação nunca mascara o erro real).
 
 ## Política de retenção
 

--- a/script/database-backup/backup.sh
+++ b/script/database-backup/backup.sh
@@ -2,6 +2,55 @@
 
 set -euo pipefail
 
+LOG_FILE=$(mktemp)
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+notify_failure() {
+  local exit_code=$1
+  local line_no=$2
+
+  if [ "${NOTIFY_EMAIL_ENABLED:-true}" != "true" ]; then
+    return 0
+  fi
+
+  if [ -z "${NOTIFY_EMAIL_TO:-}" ]; then
+    echo "NOTIFY_EMAIL_TO não configurado, pulando notificação por e-mail" >&2
+    return 0
+  fi
+
+  IFS=',' read -ra RAW_RECIPIENTS <<< "${NOTIFY_EMAIL_TO}"
+  local recipients=()
+  for r in "${RAW_RECIPIENTS[@]}"; do
+    r="$(echo -n "$r" | xargs)"
+    [ -n "$r" ] && recipients+=("$r")
+  done
+
+  if [ "${#recipients[@]}" -eq 0 ]; then
+    echo "Nenhum destinatário válido em NOTIFY_EMAIL_TO" >&2
+    return 0
+  fi
+
+  local subject="[FALHA] Backup do banco ${DATABASE_NAME} - $(date '+%Y-%m-%d %H:%M:%S') (${TZ:-UTC})"
+
+  {
+    echo "Subject: ${subject}"
+    echo "From: ${SMTP_FROM}"
+    echo "To: $(IFS=,; echo "${recipients[*]}")"
+    echo "Content-Type: text/plain; charset=UTF-8"
+    echo
+    echo "Falha no backup do banco: ${DATABASE_NAME}"
+    echo "Horário da tentativa: $(date '+%Y-%m-%d %H:%M:%S') (${TZ:-UTC})"
+    echo "Código de saída: ${exit_code} (linha ${line_no})"
+    echo
+    echo "Últimas linhas do log:"
+    tail -n 50 "${LOG_FILE}" 2>/dev/null || echo "(log indisponível)"
+  } | msmtp "${recipients[@]}" || echo "Falha ao enviar e-mail de notificação via msmtp" >&2
+
+  return 0
+}
+
+trap 'notify_failure $? $LINENO' ERR
+
 TIMESTAMP=$(date +%s)
 FILE_NAME="${DATABASE_NAME}_${TIMESTAMP}.sql.gz"
 TMP_FILE="/tmp/${FILE_NAME}"

--- a/script/database-backup/docker-compose.yml
+++ b/script/database-backup/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     image: database-backup:local
     container_name: database-backup
     build: .
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       # PostgreSQL
       DATABASE_HOST:     "${DATABASE_HOST}"

--- a/script/database-backup/docker-compose.yml
+++ b/script/database-backup/docker-compose.yml
@@ -20,3 +20,12 @@ services:
 
       CRON_SCHEDULE:     "${CRON_SCHEDULE}"
       TZ:                "${TZ}"
+
+      # SMTP / Notificações
+      SMTP_HOST:         "${SMTP_HOST}"
+      SMTP_PORT:         "${SMTP_PORT}"
+      SMTP_USER:         "${SMTP_USER}"
+      SMTP_PASS:         "${SMTP_PASS}"
+      SMTP_FROM:         "${SMTP_FROM}"
+      NOTIFY_EMAIL_TO:      "${NOTIFY_EMAIL_TO}"
+      NOTIFY_EMAIL_ENABLED: "${NOTIFY_EMAIL_ENABLED}"

--- a/script/database-backup/entrypoint.sh
+++ b/script/database-backup/entrypoint.sh
@@ -10,9 +10,26 @@ token = ${GDRIVE_TOKEN}
 root_folder_id = ${GDRIVE_FOLDER_ID}
 EOF
 
+echo "Configurando msmtp..."
+cat <<EOF > /etc/msmtprc
+defaults
+auth           on
+tls            on
+tls_trust_file /etc/ssl/certs/ca-certificates.crt
+logfile        /var/log/msmtp.log
+
+account        default
+host           ${SMTP_HOST}
+port           ${SMTP_PORT}
+from           ${SMTP_USER}
+user           ${SMTP_USER}
+password       ${SMTP_PASS}
+EOF
+chmod 600 /etc/msmtprc
+
 echo "Configuring cron job with schedule: $CRON_SCHEDULE ($TZ)"
 
-printenv | grep -E "^(DATABASE_|GDRIVE_|RETENTION_|CRON_SCHEDULE|TZ)" >> /etc/environment
+printenv | grep -E "^(DATABASE_|GDRIVE_|RETENTION_|CRON_SCHEDULE|TZ|SMTP_|NOTIFY_)" >> /etc/environment
 
 echo "$CRON_SCHEDULE /backup.sh 1> /proc/1/fd/1 2> /proc/1/fd/2" | crontab -
 


### PR DESCRIPTION
Close #477 

# Descrição
Adiciona notificação automática por e-mail no serviço database-backup em caso de falha durante a execução da rotina de backup (como erros no pg_dump, falhas no upload via rclone ou falha na aplicação de retenção).

# O que foi feito
- Adicionado cliente SMTP (msmtp) ao container:
- Atualizado o Dockerfile para instalar msmtp e gettext-base.
- Configuração dinâmica do SMTP no entrypoint.sh:
- Implementada a geração do arquivo /etc/msmtprc a partir das variáveis de ambiente SMTP_*.
- Ajustado o envelope do msmtp para utilizar o e-mail puro (SMTP_USER) no envio e manter o nome amigável (SMTP_FROM) apenas nos cabeçalhos de exibição, evitando rejeições (como o erro 555 do Gmail).
- Tratamento e envio de notificações em falhas no backup.sh:
- Adicionada função de captura via trap ... EXIT para identificar códigos de erro de execução (exit status != 0).
- Implementado disparo de e-mail informativo contendo: nome do banco, horário da tentativa (TZ) e as últimas 30 linhas do log de erro.
- Suporte a múltiplos destinatários configuráveis através de lista separada por vírgula (NOTIFY_EMAIL_TO).
- Adicionada flag NOTIFY_EMAIL_ENABLED para ligar/desligar alertas sem mover/remover configurações.
- Garantia de que a falha na entrega do e-mail não mascara a falha original do job de backup (exit status do backup é mantido).
- Adicionado no docker-compose.yml o extra_hosts: "host.docker.internal:host-gateway" para teste do backup no banco herbario_dev(127.0.0.1).

# Documentação:

- Adicionadas as novas variáveis de ambiente (SMTP_*, NOTIFY_*) nos arquivos .env.example e README.md.

- Formato da Notificação
Assunto
[FALHA] Backup do banco {DATABASE_NAME} - {CURRENT_TIME}

- Corpo do E-mail
  Banco de dados: {DATABASE_NAME}

  Data/Horário: {CURRENT_TIME}

  Código de saída: {EXIT_CODE}

  Log: Trecho com as últimas 30 linhas da saída de erro capturada pelo script.

# Validações realizadas
- Falha no backup → Notificação enviada: Testado com erro forçado no pg_dump; e-mail de alerta enviado com sucesso para todos os endereços listados em NOTIFY_EMAIL_TO (smtpstatus=250 exitcode=EX_OK).

- Múltiplos destinatários: Confirmado recebimento em múltiplos e-mails inseridos simultaneamente na lista separada por vírgula.

- Sucesso no backup → Nenhum e-mail enviado: Executado o backup completo (dump + upload no Google Drive) com sucesso; o log /var/log/msmtp.log permaneceu intocado e o processo encerrou com exit 0.

- Preservação do código de erro em falha de SMTP: Testado com SMTP_PASS incorreta; o msmtp falhou, mas a falha do backup foi preservada no container com BACKUP_EXIT=1.

- Desativação temporária (NOTIFY_EMAIL_ENABLED=false): Confirmado que o envio é ignorado mantendo a falha original no job.

- Provedor e ambiente real: Validação realizada com containers reais via docker compose build, banco PostgreSQL local e servidor SMTP real do Gmail.

# Impacto
Garante observabilidade imediata para a equipe em caso de quebra nas rotinas automáticas de backup do banco de dados, reduzindo o tempo de resposta a incidentes de desastre/restore sem acrescentar dependências pesadas ao container.