### PR TITLE
Feat: Listar e buscar tipos de relevo Api.v2

### DIFF
--- a/src/application/create-app.ts
+++ b/src/application/create-app.ts
@@ -14,6 +14,7 @@ import legacyErrors from '../middlewares/erros-middleware'
 import { generatePreview, reportPreview } from '../reports/controller'
 import { routes as createEstadoRoutes } from './estado'
 import { routes as createPaisRoutes } from './pais'
+import { routes as createRelevoRoutes } from './relevo'
 
 interface CorsParameters {
   origins: string[]
@@ -55,7 +56,8 @@ export function createApp({
 }: Parameters) {
   const routes: Route[] = [
     ...createPaisRoutes(knex),
-    ...createEstadoRoutes(knex)
+    ...createEstadoRoutes(knex),
+    ...createRelevoRoutes(knex)
   ]
   const application = new ExpressApplication({ logger })
 

--- a/src/application/relevo/BuscarRelevoController.ts
+++ b/src/application/relevo/BuscarRelevoController.ts
@@ -1,0 +1,41 @@
+import { BuscarRelevoPorIdUseCase } from '@/domain/relevo/BuscarRelevoPorIdUseCase'
+import {
+  HttpRequest, HttpResponse, StatusCode
+} from '@/library/http/common'
+import { BadRequestError } from '@/library/http/error/BadRequestError'
+import { HttpError } from '@/library/http/error/HttpError'
+import { InternalServerError } from '@/library/http/error/InternalServerError'
+import { NotFoundError } from '@/library/http/error/NotFoundError'
+import { NextHandler, RequestHandler } from '@/library/http/Server'
+
+interface Dependencies {
+  buscarRelevoPorIdUseCase: BuscarRelevoPorIdUseCase
+}
+
+export class BuscarRelevoController implements RequestHandler {
+  private readonly buscarRelevoPorIdUseCase: BuscarRelevoPorIdUseCase
+
+  constructor(dependencies: Dependencies) {
+    this.buscarRelevoPorIdUseCase = dependencies.buscarRelevoPorIdUseCase
+  }
+
+  async handle(request: HttpRequest, _next: NextHandler): Promise<HttpResponse | HttpError> {
+    const { relevoId } = request.params as { relevoId?: string }
+
+    if (relevoId === undefined || relevoId === null || relevoId === '' || !/^\d+$/.test(relevoId)) {
+      return new BadRequestError({ message: 'relevoId inválido' })
+    }
+
+    const result = await this.buscarRelevoPorIdUseCase.execute({ id: Number(relevoId) })
+
+    if (result.left()) {
+      return new InternalServerError({ message: result.value.message })
+    }
+
+    if (!result.value) {
+      return new NotFoundError({ message: 'Relevo não encontrado' })
+    }
+
+    return { statusCode: StatusCode.Ok, body: result.value }
+  }
+}

--- a/src/application/relevo/ListaRelevosController.ts
+++ b/src/application/relevo/ListaRelevosController.ts
@@ -1,0 +1,50 @@
+import { ListaRelevosUseCase } from '@/domain/relevo/ListaRelevosUseCase'
+import {
+  HttpRequest, HttpResponse, StatusCode
+} from '@/library/http/common'
+import { HttpError } from '@/library/http/error/HttpError'
+import { InternalServerError } from '@/library/http/error/InternalServerError'
+import { NextHandler, RequestHandler } from '@/library/http/Server'
+
+interface Dependencies {
+  listaRelevosUseCase: ListaRelevosUseCase
+}
+
+export class ListaRelevosController implements RequestHandler {
+  private readonly listaRelevosUseCase: ListaRelevosUseCase
+
+  constructor(dependencies: Dependencies) {
+    this.listaRelevosUseCase = dependencies.listaRelevosUseCase
+  }
+
+  async handle(request: HttpRequest, _next: NextHandler): Promise<HttpResponse | HttpError> {
+    const { nome, order } = request.params as {
+      nome?: string
+      order?: string
+    }
+
+    const result = await this.listaRelevosUseCase.execute({
+      nome,
+      order: parseOrder(order)
+    })
+
+    if (result.left()) {
+      return new InternalServerError({ message: result.value.message })
+    }
+
+    return { statusCode: StatusCode.Ok, body: result.value }
+  }
+}
+
+function parseOrder(order?: string): { column: 'id' | 'nome'; direction: 'asc' | 'desc' } | undefined {
+  if (!order) return undefined
+
+  const [column, direction] = order.split(':')
+  const normalizedColumn = column === 'nome' || column === 'id' ? column : 'id'
+  const normalizedDirection = direction === 'asc' || direction === 'desc' ? direction : 'desc'
+
+  return {
+    column: normalizedColumn,
+    direction: normalizedDirection
+  }
+}

--- a/src/application/relevo/index.ts
+++ b/src/application/relevo/index.ts
@@ -1,0 +1,35 @@
+import { type Knex } from 'knex'
+
+import { BuscarRelevoPorIdUseCase } from '@/domain/relevo/BuscarRelevoPorIdUseCase'
+import { ListaRelevosUseCase } from '@/domain/relevo/ListaRelevosUseCase'
+import { RelevoCollectionKnexAdapter } from '@/infrastructure/RelevoCollectionKnexAdapter'
+import { Method } from '@/library/http/common'
+import { Route } from '@/library/http/Router'
+
+import { BuscarRelevoController } from './BuscarRelevoController'
+import { ListaRelevosController } from './ListaRelevosController'
+
+export function routes(knex: Knex): Route[] {
+  const relevoCollection = new RelevoCollectionKnexAdapter({ knex })
+
+  return [
+    {
+      handlers: [
+        new ListaRelevosController({
+          listaRelevosUseCase: new ListaRelevosUseCase({ relevoCollection })
+        })
+      ],
+      method: Method.Get,
+      path: '/v2/relevos'
+    },
+    {
+      handlers: [
+        new BuscarRelevoController({
+          buscarRelevoPorIdUseCase: new BuscarRelevoPorIdUseCase({ relevoCollection })
+        })
+      ],
+      method: Method.Get,
+      path: '/v2/relevos/:relevoId'
+    }
+  ]
+}

--- a/src/domain/relevo/BuscarRelevoPorIdUseCase.ts
+++ b/src/domain/relevo/BuscarRelevoPorIdUseCase.ts
@@ -1,0 +1,20 @@
+import { Either } from '@/library/either/Either'
+
+import { Attributes } from './Relevo'
+import { RelevoCollection } from './RelevoCollection'
+
+interface Dependencies {
+  relevoCollection: RelevoCollection
+}
+
+export class BuscarRelevoPorIdUseCase {
+  private readonly relevoCollection: RelevoCollection
+
+  constructor(dependencies: Dependencies) {
+    this.relevoCollection = dependencies.relevoCollection
+  }
+
+  execute({ id }: { id: number }): Promise<Either<Error, Attributes | null>> {
+    return this.relevoCollection.findById(id)
+  }
+}

--- a/src/domain/relevo/ListaRelevosUseCase.ts
+++ b/src/domain/relevo/ListaRelevosUseCase.ts
@@ -1,0 +1,20 @@
+import { Either } from '@/library/either/Either'
+
+import { Attributes } from './Relevo'
+import { RelevoCollection, RelevoFilters } from './RelevoCollection'
+
+interface Dependencies {
+  relevoCollection: RelevoCollection
+}
+
+export class ListaRelevosUseCase {
+  private readonly relevoCollection: RelevoCollection
+
+  constructor(dependencies: Dependencies) {
+    this.relevoCollection = dependencies.relevoCollection
+  }
+
+  execute(filters: RelevoFilters): Promise<Either<Error, Attributes[]>> {
+    return this.relevoCollection.findAll(filters)
+  }
+}

--- a/src/domain/relevo/Relevo.ts
+++ b/src/domain/relevo/Relevo.ts
@@ -1,0 +1,24 @@
+import { Either } from '@/library/either/Either'
+
+export interface Attributes {
+  id: number
+  nome: string
+}
+
+export class Relevo {
+  readonly id: number
+  readonly nome: string
+
+  private constructor(attributes: Attributes) {
+    this.id = attributes.id
+    this.nome = attributes.nome
+  }
+
+  static create(attributes: Attributes): Either<Error, Relevo> {
+    if (!attributes.nome.trim()) {
+      return Either.left(new Error('Nome do relevo não pode ser vazio'))
+    }
+
+    return Either.right(new Relevo(attributes))
+  }
+}

--- a/src/domain/relevo/RelevoCollection.ts
+++ b/src/domain/relevo/RelevoCollection.ts
@@ -1,0 +1,18 @@
+import { Either } from '@/library/either/Either'
+
+import { Attributes } from './Relevo'
+
+export interface RelevoOrder {
+  column: 'id' | 'nome'
+  direction: 'asc' | 'desc'
+}
+
+export interface RelevoFilters {
+  nome?: string
+  order?: RelevoOrder
+}
+
+export interface RelevoCollection {
+  findAll(filters: RelevoFilters): Promise<Either<Error, Attributes[]>>
+  findById(id: number): Promise<Either<Error, Attributes | null>>
+}

--- a/src/infrastructure/RelevoCollectionKnexAdapter.ts
+++ b/src/infrastructure/RelevoCollectionKnexAdapter.ts
@@ -1,0 +1,46 @@
+import { Knex } from 'knex'
+
+import { Attributes } from '@/domain/relevo/Relevo'
+import { RelevoCollection, RelevoFilters } from '@/domain/relevo/RelevoCollection'
+import { Either } from '@/library/either/Either'
+
+import { CollectionError } from './error/CollectionError'
+
+interface Dependencies {
+  knex: Knex
+}
+
+export class RelevoCollectionKnexAdapter implements RelevoCollection {
+  private readonly knex: Knex
+
+  constructor(dependencies: Dependencies) {
+    this.knex = dependencies.knex
+  }
+
+  async findAll(filters: RelevoFilters): Promise<Either<Error, Attributes[]>> {
+    try {
+      const query = this.knex<Attributes>('relevos')
+        .select(['id', 'nome'])
+
+      if (filters.nome) {
+        query.whereILike('nome', `%${filters.nome}%`)
+      }
+
+      const order = filters.order ?? { column: 'id', direction: 'desc' }
+      query.orderBy(order.column, order.direction)
+
+      return Either.right(await query)
+    } catch (error) {
+      return Either.left(new CollectionError({ message: 'Failed to list relevos', cause: error }))
+    }
+  }
+
+  async findById(id: number): Promise<Either<Error, Attributes | null>> {
+    try {
+      const relevo = await this.knex<Attributes>('relevos').select(['id', 'nome']).where({ id }).first()
+      return Either.right(relevo ?? null)
+    } catch (error) {
+      return Either.left(new CollectionError({ message: 'Failed to find relevo', cause: error }))
+    }
+  }
+}

--- a/test/integration/relevo/lista-relevos.test.ts
+++ b/test/integration/relevo/lista-relevos.test.ts
@@ -1,0 +1,107 @@
+import {
+  afterAll, describe, expect, test
+} from 'vitest'
+
+import { createTestApp } from '../setup/app-factory'
+
+type Relevo = { id: number; nome: string }
+
+const returning = ['id', 'nome'] as const
+
+describe('GET /api/v2/relevos', () => {
+  const { agent, knex } = createTestApp()
+
+  afterAll(() => knex.destroy())
+
+  test('retorna a lista ordenada por id decrescente como padrão', async () => {
+    const nomes = [
+      'XREL Plano',
+      'XREL Inclinado',
+      'XREL Ondulado'
+    ]
+
+    const inserted = await knex('relevos')
+      .insert(nomes.map(nome => ({ nome })))
+      .returning<Relevo[]>(returning)
+
+    try {
+      const response = await agent.get('/api/v2/relevos').expect(200)
+      const expected = [...inserted].sort((a, b) => b.id - a.id)
+      expect(response.body).toEqual(expected)
+    } finally {
+      await knex('relevos').whereIn('nome', nomes).delete()
+    }
+  })
+
+  test('filtra por nome sem diferenciar maiúsculas e minúsculas', async () => {
+    const nomes = [
+      'XREL Plano',
+      'XREL Inclinado',
+      'XREL Ondulado'
+    ]
+
+    const inserted = await knex('relevos')
+      .insert(nomes.map(nome => ({ nome })))
+      .returning<Relevo[]>(returning)
+
+    try {
+      const response = await agent.get('/api/v2/relevos?nome=plano').expect(200)
+      expect(response.body).toEqual(inserted.filter(item => item.nome === 'XREL Plano'))
+    } finally {
+      await knex('relevos').whereIn('nome', nomes).delete()
+    }
+  })
+
+  test('aceita ordenação customizada por nome e id', async () => {
+    const nomes = [
+      'XREL Z',
+      'XREL A',
+      'XREL M'
+    ]
+
+    const inserted = await knex('relevos')
+      .insert(nomes.map(nome => ({ nome })))
+      .returning<Relevo[]>(returning)
+
+    try {
+      const byNameAsc = await agent.get('/api/v2/relevos?order=nome:asc').expect(200)
+      expect(byNameAsc.body).toEqual([...inserted].sort((a, b) => a.nome.localeCompare(b.nome)))
+
+      const byIdAsc = await agent.get('/api/v2/relevos?order=id:asc').expect(200)
+      expect(byIdAsc.body).toEqual([...inserted].sort((a, b) => a.id - b.id))
+    } finally {
+      await knex('relevos').whereIn('nome', nomes).delete()
+    }
+  })
+})
+
+describe('GET /api/v2/relevos/:relevoId', () => {
+  const { agent, knex } = createTestApp()
+
+  afterAll(() => knex.destroy())
+
+  test('retorna o registro encontrado', async () => {
+    const [relevo] = await knex('relevos')
+      .insert({ nome: 'XREL Relevo Encontrado' })
+      .returning<Relevo[]>(returning)
+
+    try {
+      const response = await agent.get(`/api/v2/relevos/${relevo.id}`).expect(200)
+      expect(response.body).toEqual({ id: relevo.id, nome: relevo.nome })
+    } finally {
+      await knex('relevos').where({ id: relevo.id }).delete()
+    }
+  })
+
+  test('retorna 404 para id inexistente', async () => {
+    const response = await agent.get('/api/v2/relevos/999999').expect(404)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(response.body.error.message).toMatch(/não encontrado|not found|not found/i)
+  })
+
+  test('retorna 400 para id inválido', async () => {
+    const response = await agent.get('/api/v2/relevos/abc').expect(400)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(response.body.error.message).toMatch(/inválido|invalid/i)
+  })
+})

--- a/test/integration/relevo/lista-relevos.test.ts
+++ b/test/integration/relevo/lista-relevos.test.ts
@@ -95,13 +95,15 @@ describe('GET /api/v2/relevos/:relevoId', () => {
 
   test('retorna 404 para id inexistente', async () => {
     const response = await agent.get('/api/v2/relevos/999999').expect(404)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(response.body.error.message).toMatch(/não encontrado|not found|not found/i)
+    const body = response.body as { error: { message: string } }
+
+    expect(body.error.message).toMatch(/não encontrad[ao]|not found/i)
   })
 
   test('retorna 400 para id inválido', async () => {
     const response = await agent.get('/api/v2/relevos/abc').expect(400)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(response.body.error.message).toMatch(/inválido|invalid/i)
+    const body = response.body as { error: { message: string } }
+
+    expect(body.error.message).toMatch(/inválido|invalid/i)
   })
 })


### PR DESCRIPTION
Close #491 

# O que foi feito
Foi implementado o módulo de leitura de tipos de relevo na API v2, preservando o comportamento legado da rota antiga.

## Alterações principais
- Criação do módulo de Relevo em v2 com endpoints de listagem e busca por ID:
- GET /api/v2/relevos
- GET /api/v2/relevos/:relevoId
- Suporte a filtro por nome com busca parcial e sem diferenciação de maiúsculas/minúsculas.
- Ordenação configurável por:
  - id ou nome
  - direção asc ou desc
- Ordenação padrão da listagem em id decrescente, conforme requisito.
- Validação para relevoId inválido com retorno 400.
- Retorno 404 quando o registro não existe.
- Manutenção do legado /api/relevos sem alterações.

## Cobertura de testes
- Testes de listagem com filtro
- Testes de ordenação padrão
- Testes de ordenação customizada pela UI
- Teste de busca por registro existente
- Teste de busca por registro inexistente
- Teste de relevoId inválido