### PR TITLE
Feat: listar buscar tipos vegetação Api.v2

### DIFF
--- a/src/application/create-app.ts
+++ b/src/application/create-app.ts
@@ -14,6 +14,7 @@ import legacyErrors from '../middlewares/erros-middleware'
 import { generatePreview, reportPreview } from '../reports/controller'
 import { routes as createEstadoRoutes } from './estado'
 import { routes as createPaisRoutes } from './pais'
+import { routes as createVegetacaoRoutes } from './vegetacao'
 
 interface CorsParameters {
   origins: string[]
@@ -55,7 +56,8 @@ export function createApp({
 }: Parameters) {
   const routes: Route[] = [
     ...createPaisRoutes(knex),
-    ...createEstadoRoutes(knex)
+    ...createEstadoRoutes(knex),
+    ...createVegetacaoRoutes(knex)
   ]
   const application = new ExpressApplication({ logger })
 

--- a/src/application/vegetacao/BuscarVegetacaoController.ts
+++ b/src/application/vegetacao/BuscarVegetacaoController.ts
@@ -1,0 +1,41 @@
+import { BuscarVegetacaoPorIdUseCase } from '@/domain/vegetacao/BuscarVegetacaoPorIdUseCase'
+import {
+  HttpRequest, HttpResponse, StatusCode
+} from '@/library/http/common'
+import { BadRequestError } from '@/library/http/error/BadRequestError'
+import { HttpError } from '@/library/http/error/HttpError'
+import { InternalServerError } from '@/library/http/error/InternalServerError'
+import { NotFoundError } from '@/library/http/error/NotFoundError'
+import { NextHandler, RequestHandler } from '@/library/http/Server'
+
+interface Dependencies {
+  buscarVegetacaoPorIdUseCase: BuscarVegetacaoPorIdUseCase
+}
+
+export class BuscarVegetacaoController implements RequestHandler {
+  private readonly buscarVegetacaoPorIdUseCase: BuscarVegetacaoPorIdUseCase
+
+  constructor(dependencies: Dependencies) {
+    this.buscarVegetacaoPorIdUseCase = dependencies.buscarVegetacaoPorIdUseCase
+  }
+
+  async handle(request: HttpRequest, _next: NextHandler): Promise<HttpResponse | HttpError> {
+    const { vegetacaoId } = request.params as { vegetacaoId?: string }
+
+    if (vegetacaoId === undefined || vegetacaoId === null || vegetacaoId === '' || !/^\d+$/.test(vegetacaoId)) {
+      return new BadRequestError({ message: 'vegetacaoId inválido' })
+    }
+
+    const result = await this.buscarVegetacaoPorIdUseCase.execute({ id: Number(vegetacaoId) })
+
+    if (result.left()) {
+      return new InternalServerError({ message: result.value.message })
+    }
+
+    if (!result.value) {
+      return new NotFoundError({ message: 'Vegetação não encontrada' })
+    }
+
+    return { statusCode: StatusCode.Ok, body: result.value }
+  }
+}

--- a/src/application/vegetacao/ListaVegetacoesController.ts
+++ b/src/application/vegetacao/ListaVegetacoesController.ts
@@ -1,0 +1,50 @@
+import { ListaVegetacoesUseCase } from '@/domain/vegetacao/ListaVegetacoesUseCase'
+import {
+  HttpRequest, HttpResponse, StatusCode
+} from '@/library/http/common'
+import { HttpError } from '@/library/http/error/HttpError'
+import { InternalServerError } from '@/library/http/error/InternalServerError'
+import { NextHandler, RequestHandler } from '@/library/http/Server'
+
+interface Dependencies {
+  listaVegetacoesUseCase: ListaVegetacoesUseCase
+}
+
+export class ListaVegetacoesController implements RequestHandler {
+  private readonly listaVegetacoesUseCase: ListaVegetacoesUseCase
+
+  constructor(dependencies: Dependencies) {
+    this.listaVegetacoesUseCase = dependencies.listaVegetacoesUseCase
+  }
+
+  async handle(request: HttpRequest, _next: NextHandler): Promise<HttpResponse | HttpError> {
+    const { nome, order } = request.params as {
+      nome?: string
+      order?: string
+    }
+
+    const result = await this.listaVegetacoesUseCase.execute({
+      nome,
+      order: parseOrder(order)
+    })
+
+    if (result.left()) {
+      return new InternalServerError({ message: result.value.message })
+    }
+
+    return { statusCode: StatusCode.Ok, body: result.value }
+  }
+}
+
+function parseOrder(order?: string): { column: 'id' | 'nome'; direction: 'asc' | 'desc' } | undefined {
+  if (!order) return undefined
+
+  const [column, direction] = order.split(':')
+  const normalizedColumn = column === 'nome' || column === 'id' ? column : 'id'
+  const normalizedDirection = direction === 'asc' || direction === 'desc' ? direction : 'desc'
+
+  return {
+    column: normalizedColumn,
+    direction: normalizedDirection
+  }
+}

--- a/src/application/vegetacao/index.ts
+++ b/src/application/vegetacao/index.ts
@@ -1,0 +1,35 @@
+import { type Knex } from 'knex'
+
+import { BuscarVegetacaoPorIdUseCase } from '@/domain/vegetacao/BuscarVegetacaoPorIdUseCase'
+import { ListaVegetacoesUseCase } from '@/domain/vegetacao/ListaVegetacoesUseCase'
+import { VegetacaoCollectionKnexAdapter } from '@/infrastructure/VegetacaoCollectionKnexAdapter'
+import { Method } from '@/library/http/common'
+import { Route } from '@/library/http/Router'
+
+import { BuscarVegetacaoController } from './BuscarVegetacaoController'
+import { ListaVegetacoesController } from './ListaVegetacoesController'
+
+export function routes(knex: Knex): Route[] {
+  const vegetacaoCollection = new VegetacaoCollectionKnexAdapter({ knex })
+
+  return [
+    {
+      handlers: [
+        new ListaVegetacoesController({
+          listaVegetacoesUseCase: new ListaVegetacoesUseCase({ vegetacaoCollection })
+        })
+      ],
+      method: Method.Get,
+      path: '/v2/vegetacoes'
+    },
+    {
+      handlers: [
+        new BuscarVegetacaoController({
+          buscarVegetacaoPorIdUseCase: new BuscarVegetacaoPorIdUseCase({ vegetacaoCollection })
+        })
+      ],
+      method: Method.Get,
+      path: '/v2/vegetacoes/:vegetacaoId'
+    }
+  ]
+}

--- a/src/domain/vegetacao/BuscarVegetacaoPorIdUseCase.ts
+++ b/src/domain/vegetacao/BuscarVegetacaoPorIdUseCase.ts
@@ -1,0 +1,20 @@
+import { Either } from '@/library/either/Either'
+
+import { Attributes } from './Vegetacao'
+import { VegetacaoCollection } from './VegetacaoCollection'
+
+interface Dependencies {
+  vegetacaoCollection: VegetacaoCollection
+}
+
+export class BuscarVegetacaoPorIdUseCase {
+  private readonly vegetacaoCollection: VegetacaoCollection
+
+  constructor(dependencies: Dependencies) {
+    this.vegetacaoCollection = dependencies.vegetacaoCollection
+  }
+
+  execute({ id }: { id: number }): Promise<Either<Error, Attributes | null>> {
+    return this.vegetacaoCollection.findById(id)
+  }
+}

--- a/src/domain/vegetacao/ListaVegetacoesUseCase.ts
+++ b/src/domain/vegetacao/ListaVegetacoesUseCase.ts
@@ -1,0 +1,20 @@
+import { Either } from '@/library/either/Either'
+
+import { Attributes } from './Vegetacao'
+import { VegetacaoCollection, VegetacaoFilters } from './VegetacaoCollection'
+
+interface Dependencies {
+  vegetacaoCollection: VegetacaoCollection
+}
+
+export class ListaVegetacoesUseCase {
+  private readonly vegetacaoCollection: VegetacaoCollection
+
+  constructor(dependencies: Dependencies) {
+    this.vegetacaoCollection = dependencies.vegetacaoCollection
+  }
+
+  execute(filters: VegetacaoFilters): Promise<Either<Error, Attributes[]>> {
+    return this.vegetacaoCollection.findAll(filters)
+  }
+}

--- a/src/domain/vegetacao/Vegetacao.ts
+++ b/src/domain/vegetacao/Vegetacao.ts
@@ -1,0 +1,24 @@
+import { Either } from '@/library/either/Either'
+
+export interface Attributes {
+  id: number
+  nome: string
+}
+
+export class Vegetacao {
+  readonly id: number
+  readonly nome: string
+
+  private constructor(attributes: Attributes) {
+    this.id = attributes.id
+    this.nome = attributes.nome
+  }
+
+  static create(attributes: Attributes): Either<Error, Vegetacao> {
+    if (!attributes.nome.trim()) {
+      return Either.left(new Error('Nome da vegetação não pode ser vazio'))
+    }
+
+    return Either.right(new Vegetacao(attributes))
+  }
+}

--- a/src/domain/vegetacao/VegetacaoCollection.ts
+++ b/src/domain/vegetacao/VegetacaoCollection.ts
@@ -1,0 +1,18 @@
+import { Either } from '@/library/either/Either'
+
+import { Attributes } from './Vegetacao'
+
+export interface VegetacaoOrder {
+  column: 'id' | 'nome'
+  direction: 'asc' | 'desc'
+}
+
+export interface VegetacaoFilters {
+  nome?: string
+  order?: VegetacaoOrder
+}
+
+export interface VegetacaoCollection {
+  findAll(filters: VegetacaoFilters): Promise<Either<Error, Attributes[]>>
+  findById(id: number): Promise<Either<Error, Attributes | null>>
+}

--- a/src/infrastructure/VegetacaoCollectionKnexAdapter.ts
+++ b/src/infrastructure/VegetacaoCollectionKnexAdapter.ts
@@ -1,0 +1,46 @@
+import { Knex } from 'knex'
+
+import { Attributes } from '@/domain/vegetacao/Vegetacao'
+import { VegetacaoCollection, VegetacaoFilters } from '@/domain/vegetacao/VegetacaoCollection'
+import { Either } from '@/library/either/Either'
+
+import { CollectionError } from './error/CollectionError'
+
+interface Dependencies {
+  knex: Knex
+}
+
+export class VegetacaoCollectionKnexAdapter implements VegetacaoCollection {
+  private readonly knex: Knex
+
+  constructor(dependencies: Dependencies) {
+    this.knex = dependencies.knex
+  }
+
+  async findAll(filters: VegetacaoFilters): Promise<Either<Error, Attributes[]>> {
+    try {
+      const query = this.knex<Attributes>('vegetacoes')
+        .select(['id', 'nome'])
+
+      if (filters.nome) {
+        query.whereILike('nome', `%${filters.nome}%`)
+      }
+
+      const order = filters.order ?? { column: 'id', direction: 'desc' }
+      query.orderBy(order.column, order.direction)
+
+      return Either.right(await query)
+    } catch (error) {
+      return Either.left(new CollectionError({ message: 'Failed to list vegetações', cause: error }))
+    }
+  }
+
+  async findById(id: number): Promise<Either<Error, Attributes | null>> {
+    try {
+      const vegetacao = await this.knex<Attributes>('vegetacoes').select(['id', 'nome']).where({ id }).first()
+      return Either.right(vegetacao ?? null)
+    } catch (error) {
+      return Either.left(new CollectionError({ message: 'Failed to find vegetação', cause: error }))
+    }
+  }
+}

--- a/test/integration/vegetacao/lista-vegetacoes.test.ts
+++ b/test/integration/vegetacao/lista-vegetacoes.test.ts
@@ -1,0 +1,91 @@
+import {
+  afterAll, describe, expect, test
+} from 'vitest'
+
+import { createTestApp } from '../setup/app-factory'
+
+type Vegetacao = { id: number; nome: string }
+
+const returning = ['id', 'nome'] as const
+
+describe('GET /api/v2/vegetacoes', () => {
+  const { agent, knex } = createTestApp()
+
+  afterAll(() => knex.destroy())
+
+  test('retorna a lista ordenada por id decrescente como padrão', async () => {
+    const nomes = ['XVEG Mata Atlântica', 'XVEG Restinga', 'XVEG Campo']
+
+    const inserted = await knex('vegetacoes')
+      .insert(nomes.map(nome => ({ nome })))
+      .returning<Vegetacao[]>(returning)
+
+    try {
+      const response = await agent.get('/api/v2/vegetacoes').expect(200)
+      const expected = [...inserted].sort((a, b) => b.id - a.id)
+      expect(response.body).toEqual(expected)
+    } finally {
+      await knex('vegetacoes').whereIn('nome', nomes).delete()
+    }
+  })
+
+  test('filtra por nome sem diferenciar maiúsculas e minúsculas', async () => {
+    const nomes = ['XVEG Floresta', 'XVEG Cerrado', 'XVEG Outros']
+    const inserted = await knex('vegetacoes')
+      .insert(nomes.map(nome => ({ nome })))
+      .returning<Vegetacao[]>(returning)
+
+    try {
+      const response = await agent.get('/api/v2/vegetacoes?nome=floresta').expect(200)
+      expect(response.body).toEqual(inserted.filter(item => item.nome === 'XVEG Floresta'))
+    } finally {
+      await knex('vegetacoes').whereIn('nome', nomes).delete()
+    }
+  })
+
+  test('aceita ordenação customizada por nome e id', async () => {
+    const nomes = ['XVEG Z', 'XVEG A', 'XVEG M']
+    const inserted = await knex('vegetacoes')
+      .insert(nomes.map(nome => ({ nome })))
+      .returning<Vegetacao[]>(returning)
+
+    try {
+      const byNameAsc = await agent.get('/api/v2/vegetacoes?order=nome:asc').expect(200)
+      expect(byNameAsc.body).toEqual([...inserted].sort((a, b) => a.nome.localeCompare(b.nome)))
+
+      const byIdAsc = await agent.get('/api/v2/vegetacoes?order=id:asc').expect(200)
+      expect(byIdAsc.body).toEqual([...inserted].sort((a, b) => a.id - b.id))
+    } finally {
+      await knex('vegetacoes').whereIn('nome', nomes).delete()
+    }
+  })
+})
+
+describe('GET /api/v2/vegetacoes/:vegetacaoId', () => {
+  const { agent, knex } = createTestApp()
+
+  afterAll(() => knex.destroy())
+
+  test('retorna o registro encontrado', async () => {
+    const [vegetacao] = await knex('vegetacoes')
+      .insert({ nome: 'XVEG Vegetação Encontrada' })
+      .returning<Vegetacao[]>(returning)
+
+    try {
+      const response = await agent.get(`/api/v2/vegetacoes/${vegetacao.id}`).expect(200)
+      expect(response.body).toEqual({ id: vegetacao.id, nome: vegetacao.nome })
+    } finally {
+      await knex('vegetacoes').where({ id: vegetacao.id }).delete()
+    }
+  })
+
+  test('retorna 404 para id inexistente', async () => {
+    const response = await agent.get('/api/v2/vegetacoes/999999').expect(404)
+    expect(response.body.error.message).toMatch(/não encontrado|not found|not found/i)
+  })
+
+  test('retorna 400 para id inválido', async () => {
+    const response = await agent.get('/api/v2/vegetacoes/abc').expect(400)
+    expect(response.body.error.message).toMatch(/inválido|invalid/i)
+  })
+})

--- a/test/integration/vegetacao/lista-vegetacoes.test.ts
+++ b/test/integration/vegetacao/lista-vegetacoes.test.ts
@@ -95,7 +95,7 @@ describe('GET /api/v2/vegetacoes/:vegetacaoId', () => {
     const response = await agent.get('/api/v2/vegetacoes/999999').expect(404)
     const body = response.body as { error: { message: string } }
 
-    expect(body.error.message).toMatch(/não encontrado|not found/i)
+    expect(body.error.message).toMatch(/não encontrad[ao]|not found/i)
   })
 
   test('retorna 400 para id inválido', async () => {

--- a/test/integration/vegetacao/lista-vegetacoes.test.ts
+++ b/test/integration/vegetacao/lista-vegetacoes.test.ts
@@ -14,7 +14,11 @@ describe('GET /api/v2/vegetacoes', () => {
   afterAll(() => knex.destroy())
 
   test('retorna a lista ordenada por id decrescente como padrão', async () => {
-    const nomes = ['XVEG Mata Atlântica', 'XVEG Restinga', 'XVEG Campo']
+    const nomes = [
+      'XVEG Mata Atlântica',
+      'XVEG Restinga',
+      'XVEG Campo'
+    ]
 
     const inserted = await knex('vegetacoes')
       .insert(nomes.map(nome => ({ nome })))
@@ -30,7 +34,11 @@ describe('GET /api/v2/vegetacoes', () => {
   })
 
   test('filtra por nome sem diferenciar maiúsculas e minúsculas', async () => {
-    const nomes = ['XVEG Floresta', 'XVEG Cerrado', 'XVEG Outros']
+    const nomes = [
+      'XVEG Floresta',
+      'XVEG Cerrado',
+      'XVEG Outros'
+    ]
     const inserted = await knex('vegetacoes')
       .insert(nomes.map(nome => ({ nome })))
       .returning<Vegetacao[]>(returning)
@@ -44,7 +52,11 @@ describe('GET /api/v2/vegetacoes', () => {
   })
 
   test('aceita ordenação customizada por nome e id', async () => {
-    const nomes = ['XVEG Z', 'XVEG A', 'XVEG M']
+    const nomes = [
+      'XVEG Z',
+      'XVEG A',
+      'XVEG M'
+    ]
     const inserted = await knex('vegetacoes')
       .insert(nomes.map(nome => ({ nome })))
       .returning<Vegetacao[]>(returning)
@@ -81,11 +93,15 @@ describe('GET /api/v2/vegetacoes/:vegetacaoId', () => {
 
   test('retorna 404 para id inexistente', async () => {
     const response = await agent.get('/api/v2/vegetacoes/999999').expect(404)
-    expect(response.body.error.message).toMatch(/não encontrado|not found|not found/i)
+    const body = response.body as { error: { message: string } }
+
+    expect(body.error.message).toMatch(/não encontrado|not found/i)
   })
 
   test('retorna 400 para id inválido', async () => {
     const response = await agent.get('/api/v2/vegetacoes/abc').expect(400)
-    expect(response.body.error.message).toMatch(/inválido|invalid/i)
+    const body = response.body as { error: { message: string } }
+
+    expect(body.error.message).toMatch(/inválido|invalid/i)
   })
 })


### PR DESCRIPTION
Close #489

# O que foi feito
Foi implementado o módulo de leitura de tipos de vegetação na API v2, preservando o comportamento legado da rota antiga.

## Alterações principais
- Criação do módulo de Vegetação em v2 com endpoints de listagem e busca por ID:
- GET /api/v2/vegetacoes
- GET /api/v2/vegetacoes/:vegetacaoId
- Suporte a filtro por nome com busca parcial e sem diferenciação de maiúsculas/minúsculas.
- Ordenação configurável por:
  - id ou nome
  - direção asc ou desc
- Ordenação padrão da listagem em id decrescente, conforme requisito.
- Validação para vegetacaoId inválido com retorno 400.
- Retorno 404 quando o registro não existe.
- Manutenção do legado /api/vegetacoes sem alterações.

## Cobertura de testes
- Testes de listagem com filtro
- Testes de ordenação padrão
- Testes de ordenação customizada pela UI
- Teste de busca por registro existente
- Teste de busca por registro inexistente
- Teste de vegetacaoId inválido