### PR TITLE
Fix: A coluna numero da fase sucessional foi renomeada para id

### DIFF
--- a/src/controllers/locais-coleta-controller.js
+++ b/src/controllers/locais-coleta-controller.js
@@ -168,11 +168,7 @@ export const cadastrarFaseSucessional = (request, response, next) => {
                 throw new BadRequestExeption(306);
             }
         })
-        .then(() => FaseSucessional.max('numero', { transaction }))
-        .then(maxNumero => {
-            const proximoNumero = (Number(maxNumero) || 0) + 1;
-            return FaseSucessional.create({ numero: proximoNumero, nome }, transaction);
-        });
+        .then(() => FaseSucessional.create({ nome }, { transaction }));
 
     sequelize.transaction(callback)
         .then(faseCriada => {
@@ -196,7 +192,7 @@ export const buscarFasesSucessionais = (request, response, next) => {
 
     Promise.resolve()
         .then(() => FaseSucessional.findAndCountAll({
-            attributes: ['numero', 'nome'],
+            attributes: ['id', 'nome'],
             where,
             order: [['nome', 'ASC']],
         }))

--- a/src/controllers/pendencias-controller.js
+++ b/src/controllers/pendencias-controller.js
@@ -1450,7 +1450,7 @@ export const aprovarPendencia = async (alteracao, hcf, transaction) => {
     if (alteracao.fase_sucessional_id !== undefined) {
         if (alteracao.fase_sucessional_id !== null) {
             const faseSucessional = await FaseSucessional.findOne({
-                where: { numero: alteracao.fase_sucessional_id },
+                where: { id: alteracao.fase_sucessional_id },
                 transaction,
                 raw: true,
                 nest: true,
@@ -1850,7 +1850,7 @@ export async function visualizar(request, response, next) {
         }
 
         if (objetoAlterado.fase_sucessional_id !== undefined) {
-            parametros.faseSucessional = await FaseSucessional.findOne({ where: { numero: objetoAlterado.fase_sucessional_id }, raw: true, nest: true });
+            parametros.faseSucessional = await FaseSucessional.findOne({ where: { id: objetoAlterado.fase_sucessional_id }, raw: true, nest: true });
         }
 
         if (objetoAlterado.vegetacao_id !== undefined) {

--- a/src/controllers/tombos-controller.js
+++ b/src/controllers/tombos-controller.js
@@ -131,7 +131,7 @@ export const cadastro = (request, response, next) => {
                 if (paisagem && paisagem.fase_sucessional_id) {
                     return FaseSucessional.findOne({
                         where: {
-                            numero: paisagem.fase_sucessional_id,
+                            id: paisagem.fase_sucessional_id,
                         },
                         transaction,
                     });
@@ -950,7 +950,7 @@ export const getDadosCadTombo = (request, response, next) => {
             retorno.vegetacoes = vegetacoes.rows;
         })
         .then(() => FaseSucessional.findAndCountAll({
-            attributes: ['numero', 'nome'],
+            attributes: ['id', 'nome'],
             order: [['nome', 'ASC']],
             transaction,
         }))
@@ -1256,7 +1256,7 @@ export const obterTombo = async (request, response, next) => {
                     relevoInicial: tombo.relevo !== null ? tombo.relevo?.nome : '',
                     idVegetacaoInicial: tombo.vegetaco !== null ? tombo.vegetaco?.id : '',
                     vegetacaoInicial: tombo.vegetaco !== null ? tombo.vegetaco?.nome : '',
-                    idFaseInicial: tombo.fase_sucessional !== null ? tombo.fase_sucessional?.numero : '',
+                    idFaseInicial: tombo.fase_sucessional !== null ? tombo.fase_sucessional?.id : '',
                     faseInicial: tombo.fase_sucessional !== null ? tombo.fase_sucessional?.nome : '',
                     colecaoInicial: tombo.colecoes_anexa !== null ? tombo.colecoes_anexa?.tipo : '',
                     complementoInicial: tombo.localizacao !== null && tombo.localizacao !== undefined ? tombo.localizacao?.complemento : '',

--- a/src/database/migration/20260826120203_rename_fase_sucessional_numero_to_id.ts
+++ b/src/database/migration/20260826120203_rename_fase_sucessional_numero_to_id.ts
@@ -1,0 +1,31 @@
+import { Knex } from 'knex'
+
+export async function run(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('fase_sucessional', table => {
+    table.renameColumn('numero', 'id')
+  })
+
+  await knex.raw(`
+    CREATE SEQUENCE IF NOT EXISTS fase_sucessional_id_seq;
+  `)
+
+  await knex.raw(`
+    SELECT setval(
+      'fase_sucessional_id_seq',
+      COALESCE((SELECT MAX(id) FROM fase_sucessional), 1),
+      true
+    )
+  `)
+
+  await knex.schema.alterTable('fase_sucessional', table => {
+    table.bigInteger('id')
+      .notNullable()
+      .defaultTo(knex.raw('nextval(\'fase_sucessional_id_seq\')'))
+      .alter()
+  })
+
+  await knex.raw(`
+    ALTER SEQUENCE fase_sucessional_id_seq
+    OWNED BY fase_sucessional.id
+  `)
+}

--- a/src/models/FaseSucessional.js
+++ b/src/models/FaseSucessional.js
@@ -5,7 +5,7 @@ function associate(/* modelos */) {
 export default (Sequelize, DataTypes) => {
 
     const attributes = {
-        numero: {
+        id: {
             type: DataTypes.INTEGER,
             autoIncrement: true,
             primaryKey: true,

--- a/test/integration/setup/schema.sql
+++ b/test/integration/setup/schema.sql
@@ -566,7 +566,7 @@ ALTER SEQUENCE public.familias_id_seq OWNED BY public.familias.id;
 --
 
 CREATE TABLE public.fase_sucessional (
-    numero bigint NOT NULL,
+    id bigint NOT NULL,
     nome character varying(200) NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
@@ -575,6 +575,28 @@ CREATE TABLE public.fase_sucessional (
 
 --
 -- TOC entry 244 (class 1259 OID 30988)
+-- Name: fase_sucessional_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.fase_sucessional_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- TOC entry 5014 (class 0 OID 0)
+-- Dependencies: 244
+-- Name: fase_sucessional_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.fase_sucessional_id_seq OWNED BY public.fase_sucessional.id;
+
+
+--
+-- TOC entry 245 (class 1259 OID 30988)
 -- Name: generos; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1897,7 +1919,15 @@ ALTER TABLE ONLY public.familias
 --
 
 ALTER TABLE ONLY public.fase_sucessional
-    ADD CONSTRAINT idx_41101_primary PRIMARY KEY (numero);
+    ADD CONSTRAINT idx_41101_primary PRIMARY KEY (id);
+
+
+--
+-- TOC entry 4530 (class 2604 OID 32603)
+-- Name: fase_sucessional id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fase_sucessional ALTER COLUMN id SET DEFAULT nextval('public.fase_sucessional_id_seq'::regclass);
 
 
 --
@@ -2548,7 +2578,7 @@ CREATE INDEX idx_41296_fk_variedades_genero ON public.variedades USING btree (ge
 --
 
 ALTER TABLE ONLY public.locais_coleta
-    ADD CONSTRAINT fk_99i0itontmoklfxmoo8armtnv FOREIGN KEY (fase_numero) REFERENCES public.fase_sucessional(numero) ON UPDATE RESTRICT ON DELETE RESTRICT;
+    ADD CONSTRAINT fk_99i0itontmoklfxmoo8armtnv FOREIGN KEY (fase_numero) REFERENCES public.fase_sucessional(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --
@@ -2665,7 +2695,7 @@ ALTER TABLE ONLY public.locais_coleta
 --
 
 ALTER TABLE ONLY public.locais_coleta
-    ADD CONSTRAINT fk_locais_coleta_fase_sucessional1 FOREIGN KEY (fase_sucessional_id) REFERENCES public.fase_sucessional(numero) ON UPDATE RESTRICT ON DELETE RESTRICT;
+    ADD CONSTRAINT fk_locais_coleta_fase_sucessional1 FOREIGN KEY (fase_sucessional_id) REFERENCES public.fase_sucessional(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
 
 
 --


### PR DESCRIPTION
Close #488 
# Descrição
Foi realizada a migração e refatoração da tabela fase_sucessional para renomear a PK numero para id, alinhando a estrutura com os demais catálogos de paisagem (solos, relevos e vegetações) e atualizando o código legado e suas chaves estrangeiras.

## O que mudou
- ajusta o model de fase_sucessional
- remove dependências legadas que consultavam numero
- alinha a API e os pontos de negócio com o padrão { id, nome }
- adiciona migration de compatibilidade para bancos que ainda possuem coluna antiga
- atualiza o schema usado em testes de integração

## Por que
fase_sucessional era o único catálogo de paisagem cujo identificador principal não seguia o padrão dos outros modelos. Isso criava exceções no código e dificultava a padronização da API nova.

## Compatibilidade
- os valores existentes não são alterados
os seeds 7, 8 e 9 continuam com os mesmos números
- a migration cobre o caso de banco ainda com numero
- o código legado passa a consultar por id